### PR TITLE
Syntax error fix

### DIFF
--- a/app/Http/Controllers/Admin/Jexactyl/RegistrationController.php
+++ b/app/Http/Controllers/Admin/Jexactyl/RegistrationController.php
@@ -26,7 +26,7 @@ class RegistrationController extends Controller
      */
     public function __construct(
         AlertsMessageBag $alert,
-        SettingsRepositoryInterface $settings,
+        SettingsRepositoryInterface $settings
     ) {
         $this->alert = $alert;
         $this->settings = $settings;

--- a/app/Http/Controllers/Admin/Jexactyl/RenewalController.php
+++ b/app/Http/Controllers/Admin/Jexactyl/RenewalController.php
@@ -26,7 +26,7 @@ class RenewalController extends Controller
      */
     public function __construct(
         AlertsMessageBag $alert,
-        SettingsRepositoryInterface $settings,
+        SettingsRepositoryInterface $settings
     ) {
         $this->alert = $alert;
         $this->settings = $settings;

--- a/app/Http/Controllers/Admin/Jexactyl/StoreController.php
+++ b/app/Http/Controllers/Admin/Jexactyl/StoreController.php
@@ -26,7 +26,7 @@ class StoreController extends Controller
      */
     public function __construct(
         AlertsMessageBag $alert,
-        SettingsRepositoryInterface $settings,
+        SettingsRepositoryInterface $settings
     ) {
         $this->alert = $alert;
         $this->settings = $settings;

--- a/app/Http/Controllers/Admin/Jexactyl/ThemeController.php
+++ b/app/Http/Controllers/Admin/Jexactyl/ThemeController.php
@@ -26,7 +26,7 @@ class ThemeController extends Controller
      */
     public function __construct(
         SettingsRepositoryInterface $settings,
-        AlertsMessageBag $alert,
+        AlertsMessageBag $alert
     ) 
     {
         $this->alert = $alert;


### PR DESCRIPTION
Fixes the `syntax error, unexpected ')', expecting variable (T_VARIABLE)` (or similar) error.
Seems to only affect Debian systems, not sure however, have not tested.