### PR TITLE
Fixed user registration not working with discord.

### DIFF
--- a/app/Http/Controllers/Auth/DiscordController.php
+++ b/app/Http/Controllers/Auth/DiscordController.php
@@ -72,7 +72,7 @@ class DiscordController extends Controller
 
             return redirect('/');
         } else {
-            if ($this->settings->get('jexactyl::registration:enabled') == 'false') return;
+            if ($this->settings->get('jexactyl::discord:enabled') == 'false') return;
 
             $username = $this->genString();
             $data = [


### PR DESCRIPTION
Fixed an issue where if you turned off the email registration, but try to use discord registration, it does not work. to fix that issue we are checking the `discord:enabled` instead of `registration:enabled`, that allows users to register with discord without turning on email registration!