### PR TITLE
Rebuild Discord OAuth. Resolves Issue#55. References PR#64

### DIFF
--- a/app/Http/Controllers/Api/Client/AccountController.php
+++ b/app/Http/Controllers/Api/Client/AccountController.php
@@ -2,11 +2,16 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Client;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Pterodactyl\Models\User;
 use Illuminate\Http\Response;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Facades\Activity;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
 use Pterodactyl\Services\Users\UserUpdateService;
 use Pterodactyl\Transformers\Api\Client\AccountTransformer;
 use Pterodactyl\Http\Requests\Api\Client\Account\UpdateEmailRequest;
@@ -98,11 +103,47 @@ class AccountController extends ClientApiController
         $original = $request->user()->username;
 
         $this->updateService->handle($request->user(), $request->validated());
-    
+
         Activity::event('user:account.username-changed')
             ->property(['old' => $original, 'new' => $request->input('username')])
             ->log();
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);
+    }
+
+    public function discord(): JsonResponse
+    {
+        return new JsonResponse([
+            'https://discord.com/api/oauth2/authorize?'
+            . 'client_id=' . $this->settings->get('jexactyl::discord:id')
+            . '&redirect_uri=' . route('api:client.account.discord.callback')
+            . '&response_type=code&scope=identify%20email%20guilds%20guilds.join&prompt=none',
+        ], 200, [], null, false);
+    }
+
+    public function discordCallback(Request $request): RedirectResponse
+    {
+        $code = Http::asForm()->post('https://discord.com/api/oauth2/token', [
+            'client_id' => $this->settings->get('jexactyl::discord:id'),
+            'client_secret' => $this->settings->get('jexactyl::discord:secret'),
+            'grant_type' => 'authorization_code',
+            'code' => $request->input('code'),
+            'redirect_uri' => route('api:client.account.discord.callback'),
+        ]);
+
+        if (!$code->ok()) {
+            return redirect('/account');
+        }
+
+        $req = json_decode($code->body());
+        if (preg_match('(email|identify)', $req->scope) !== 1) {
+            return redirect('/account');
+        }
+
+        $discord = json_decode(Http::withHeaders(['Authorization' => 'Bearer ' . $req->access_token])->asForm()->get('https://discord.com/api/users/@me')->body());
+
+        User::query()->where('id', '=', Auth::user()->id)->update(['discord_id' => $discord->id]);
+
+        return redirect('/account');
     }
 }

--- a/app/Http/Controllers/Auth/DiscordController.php
+++ b/app/Http/Controllers/Auth/DiscordController.php
@@ -2,18 +2,16 @@
 
 namespace Pterodactyl\Http\Controllers\Auth;
 
-use Pterodactyl\Models\User;
+use Exception;
 use Illuminate\Http\Request;
+use Pterodactyl\Models\User;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
-use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Exceptions\DisplayException;
+use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Services\Users\UserCreationService;
 use Pterodactyl\Exceptions\Model\DataValidationException;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Pterodactyl\Contracts\Repository\SettingsRepositoryInterface;
 
 class DiscordController extends Controller
@@ -24,8 +22,7 @@ class DiscordController extends Controller
     public function __construct(
         UserCreationService $creationService,
         SettingsRepositoryInterface $settings,
-    )
-    {
+    ) {
         $this->creationService = $creationService;
         $this->settings = $settings;
     }
@@ -37,15 +34,15 @@ class DiscordController extends Controller
     {
         return new JsonResponse([
             'https://discord.com/api/oauth2/authorize?'
-            .'client_id='.$this->settings->get('jexactyl::discord:id')
-            .'&redirect_uri='.$this->settings->get('jexactyl::discord:redirect')
-            .'&response_type=code&scope=identify%20email%20guilds%20guilds.join&prompt=none'
+            . 'client_id=' . $this->settings->get('jexactyl::discord:id')
+            . '&redirect_uri=' . $this->settings->get('jexactyl::discord:redirect')
+            . '&response_type=code&scope=identify%20email%20guilds%20guilds.join&prompt=none',
         ], 200, [], null, false);
     }
 
     /**
      * Returns data from the Discord API to login.
-     * 
+     *
      * @throws DisplayException
      * @throws DataValidationException
      */
@@ -59,25 +56,32 @@ class DiscordController extends Controller
             'redirect_uri' => $this->settings->get('jexactyl::discord:redirect'),
         ]);
 
-        if (!$code->ok()) return;
+        if (!$code->ok()) {
+            return;
+        }
 
         $req = json_decode($code->body());
-        if (preg_match("(email|guilds|identify|guilds.join)", $req->scope) !== 1) return;
+        if (preg_match('(email|guilds|identify|guilds.join)', $req->scope) !== 1) {
+            return;
+        }
 
-        $discord = json_decode(Http::withHeaders(["Authorization" => "Bearer ".$req->access_token])->asForm()->get('https://discord.com/api/users/@me')->body());
+        $discord = json_decode(Http::withHeaders(['Authorization' => 'Bearer ' . $req->access_token])->asForm()->get('https://discord.com/api/users/@me')->body());
 
-        if (User::where('email', $discord->email)->exists()) {
-            $user = User::where('email', $discord->email)->first();
+        if (User::where('discord_id', $discord->id)->exists()) {
+            $user = User::where('discord_id', $discord->id)->first();
             Auth::loginUsingId($user->id, true);
 
             return redirect('/');
         } else {
-            if ($this->settings->get('jexactyl::discord:enabled') == 'false') return;
+            if ($this->settings->get('jexactyl::discord:enabled') == 'false') {
+                return;
+            }
 
             $username = $this->genString();
             $data = [
                 'email' => $discord->email,
                 'username' => $username,
+                'discord_id' => $discord->id,
                 'name_first' => $discord->username,
                 'name_last' => $discord->discriminator,
                 'password' => $this->genString(),
@@ -93,7 +97,9 @@ class DiscordController extends Controller
 
             try {
                 $this->creationService->handle($data);
-            } catch (Exception $e) { return; }
+            } catch (Exception $e) {
+                return;
+            }
 
             $user = User::where('username', $username)->first();
             Auth::loginUsingId($user->id, true);
@@ -108,7 +114,8 @@ class DiscordController extends Controller
      */
     public function genString(): string
     {
-        $chars = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        $chars = '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
         return substr(str_shuffle($chars), 0, 16);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ use Pterodactyl\Notifications\SendPasswordReset as ResetPasswordNotification;
  * @property string $uuid
  * @property string $username
  * @property string $email
+ * @property string $discord_id
  * @property string|null $name_first
  * @property string|null $name_last
  * @property string $password
@@ -130,6 +131,7 @@ class User extends Model implements
         'external_id',
         'username',
         'email',
+        'discord_id',
         'name_first',
         'name_last',
         'password',

--- a/database/migrations/2022_07_23_190604_add_discord_id_to_users.php
+++ b/database/migrations/2022_07_23_190604_add_discord_id_to_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDiscordIdToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('discord_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('discord_id');
+        });
+    }
+}

--- a/resources/scripts/api/account/getDiscord.ts
+++ b/resources/scripts/api/account/getDiscord.ts
@@ -1,0 +1,7 @@
+import http from "@/api/http";
+
+export default (): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        http.get('/api/client/account/discord').then((data) => resolve(data.data)).catch(reject);
+    });
+};

--- a/resources/scripts/components/App.tsx
+++ b/resources/scripts/components/App.tsx
@@ -20,6 +20,7 @@ interface ExtendedWindow extends Window {
         username: string;
         email: string;
         /* eslint-disable camelcase */
+        discord_id: string;
         root_admin: boolean;
         use_totp: boolean;
         referral_code: string;
@@ -40,6 +41,7 @@ const App = () => {
             uuid: PterodactylUser.uuid,
             username: PterodactylUser.username,
             email: PterodactylUser.email,
+            discordId: PterodactylUser.discord_id,
             language: PterodactylUser.language,
             rootAdmin: PterodactylUser.root_admin,
             useTotp: PterodactylUser.use_totp,

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -9,6 +9,7 @@ import PageContentBlock from '@/components/elements/PageContentBlock';
 import UpdateUsernameForm from '@/components/dashboard/forms/UpdateUsernameForm';
 import AddReferralCodeForm from '@/components/dashboard/forms/AddReferralCodeForm';
 import UpdateEmailAddressForm from '@/components/dashboard/forms/UpdateEmailAddressForm';
+import DiscordAccountForm from "@/components/dashboard/forms/DiscordAccountForm";
 
 const Container = styled.div`
     ${tw`flex flex-wrap`};
@@ -50,6 +51,9 @@ export default () => {
                 </ContentBox>
                 <ContentBox css={tw`mt-8 sm:mt-0 sm:ml-8`} title={'Referral Codes'} showFlashes={'account:referral'}>
                     <AddReferralCodeForm />
+                </ContentBox>
+                <ContentBox title={'Discord Account'} showFlashes={'account:discord'} className={'mt-8'}>
+                    <DiscordAccountForm/>
                 </ContentBox>
             </Container>
         </PageContentBlock>

--- a/resources/scripts/components/dashboard/forms/DiscordAccountForm.tsx
+++ b/resources/scripts/components/dashboard/forms/DiscordAccountForm.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {useStoreState} from "@/state/hooks";
+import {Button} from "@/components/elements/button";
+import getDiscord from "@/api/account/getDiscord";
+
+export default () => {
+    const discordId = useStoreState((state) => state.user.data!.discordId);
+    const enabled = useStoreState((state) => state.settings.data!.registration.discord);
+
+    const link = () => {
+        getDiscord().then((data) => {
+            window.location.href = data;
+        });
+    };
+
+    return (
+        <div>
+            {enabled === 'true' ?
+                <>
+                    {discordId ?
+                        <p>Your account is currently linked to the Discord: {discordId}</p>
+                        :
+                        <div>
+                            <p>You are not currently linked to Discord.</p>
+                            <Button.Success className={'mt-4'} onClick={() => link()}>
+                                Link
+                            </Button.Success>
+                        </div>
+                    }
+                </>
+                :
+                <p>Discord authentication is currently disabled.</p>
+            }
+        </div>
+    )
+};

--- a/resources/scripts/state/user.ts
+++ b/resources/scripts/state/user.ts
@@ -5,6 +5,7 @@ export interface UserData {
     uuid: string;
     username: string;
     email: string;
+    discordId: string;
     language: string;
     rootAdmin: boolean;
     useTotp: boolean;

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -41,6 +41,9 @@ Route::prefix('/account')->middleware(AccountSubject::class)->group(function () 
     Route::put('/use-referral', [Client\ReferralsController::class, 'use']);
     Route::delete('/referrals/{code}', [Client\ReferralsController::class, 'delete']);
 
+    Route::get('/discord', [Client\AccountController::class, 'discord'])->name('api:client.account.discord');
+    Route::get('/discord/callback', [Client\AccountController::class, 'discordCallback'])->name('api:client.account.discord.callback');
+
     Route::get('/api-keys', [Client\ApiKeyController::class, 'index']);
     Route::post('/api-keys', [Client\ApiKeyController::class, 'store']);
     Route::delete('/api-keys/{identifier}', [Client\ApiKeyController::class, 'delete']);


### PR DESCRIPTION
Rebuild Discord OAuth to allow account linking. Will allow for any account to link to Discord allowing login. Will also be useful for an Application API filter to search with Discord ID.