### PR TITLE
Small correction of a broken link

### DIFF
--- a/app/Http/Controllers/Admin/Jexactyl/StoreController.php
+++ b/app/Http/Controllers/Admin/Jexactyl/StoreController.php
@@ -73,7 +73,7 @@ class StoreController extends Controller
             $this->settings->set('jexactyl::' . $key, $value);
         }
 
-        $this->alert->success('If you have enabled a payment gateway, please remember to configure them. <a href="https://documentation.jexactyl.com">Documentation</a>')->flash();
+        $this->alert->success('If you have enabled a payment gateway, please remember to configure them. <a href="https://docs.jexactyl.com">Documentation</a>')->flash();
 
         return redirect()->route('admin.jexactyl.store');
     }


### PR DESCRIPTION
When we change the prices of the store, we are shown a banner that redirects to the docs, but the link did not work.