### PR TITLE
fix(api): add missing `discord_id` validation

### DIFF
--- a/app/Http/Requests/Api/Application/Users/StoreUserRequest.php
+++ b/app/Http/Requests/Api/Application/Users/StoreUserRequest.php
@@ -21,6 +21,7 @@ class StoreUserRequest extends ApplicationApiRequest
 
         $response = collect($rules)->only([
             'external_id',
+            'discord_id',
             'email',
             'username',
             'password',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,7 +28,7 @@ use Pterodactyl\Notifications\SendPasswordReset as ResetPasswordNotification;
  * @property string $uuid
  * @property string $username
  * @property string $email
- * @property string $discord_id
+ * @property string|null $discord_id
  * @property string|null $name_first
  * @property string|null $name_last
  * @property string $password
@@ -185,6 +185,7 @@ class User extends Model implements
         'uuid' => 'required|string|size:36|unique:users,uuid',
         'email' => 'required|email|between:1,191|unique:users,email',
         'external_id' => 'sometimes|nullable|string|max:191|unique:users,external_id',
+        'discord_id' => 'nullable|string|regex:/^[0-9]{17,20}$/|unique:users,discord_id',
         'username' => 'required|between:1,191|unique:users,username',
         'name_first' => 'required|string|between:1,191',
         'name_last' => 'required|string|between:1,191',

--- a/resources/views/admin/jexactyl/registration.blade.php
+++ b/resources/views/admin/jexactyl/registration.blade.php
@@ -62,7 +62,7 @@
                                 <label class="control-label">Discord Client ID</label>
                                 <div>
                                     <input type="text" class="form-control" name="discord:id" value="{{ $discord_id }}" />
-                                    <p class="text-muted"><small>The client ID for your OAuth application. Typically 17-20 numbers long.</small></p>
+                                    <p class="text-muted"><small>The client ID for your OAuth application. Typically 17-20 digits long.</small></p>
                                 </div>
                             </div>
                             <div class="form-group col-md-4">

--- a/resources/views/admin/jexactyl/registration.blade.php
+++ b/resources/views/admin/jexactyl/registration.blade.php
@@ -62,7 +62,7 @@
                                 <label class="control-label">Discord Client ID</label>
                                 <div>
                                     <input type="text" class="form-control" name="discord:id" value="{{ $discord_id }}" />
-                                    <p class="text-muted"><small>The client ID for your OAuth application. Typically 18-19 numbers long.</small></p>
+                                    <p class="text-muted"><small>The client ID for your OAuth application. Typically 17-20 numbers long.</small></p>
                                 </div>
                             </div>
                             <div class="form-group col-md-4">


### PR DESCRIPTION
Fixes the `discord_id` field for API requests by adding the required validation rules + a small message typo.