### PR TITLE
fix(tests): add missing User field

### DIFF
--- a/tests/Integration/Api/Application/Users/ExternalUserControllerTest.php
+++ b/tests/Integration/Api/Application/Users/ExternalUserControllerTest.php
@@ -22,8 +22,8 @@ class ExternalUserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonStructure([
             'object',
             'attributes' => [
-                'id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name',
-                'language', 'root_admin', '2fa', 'created_at', 'updated_at',
+                'id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name',
+                'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at',
             ],
         ]);
 
@@ -32,6 +32,7 @@ class ExternalUserControllerTest extends ApplicationApiIntegrationTestCase
             'attributes' => [
                 'id' => $user->id,
                 'external_id' => $user->external_id,
+                'discord_id' => $user->discord_id,
                 'uuid' => $user->uuid,
                 'username' => $user->username,
                 'email' => $user->email,

--- a/tests/Integration/Api/Application/Users/UserControllerTest.php
+++ b/tests/Integration/Api/Application/Users/UserControllerTest.php
@@ -24,8 +24,8 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonStructure([
             'object',
             'data' => [
-                ['object', 'attributes' => ['id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at']],
-                ['object', 'attributes' => ['id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at']],
+                ['object', 'attributes' => ['id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at']],
+                ['object', 'attributes' => ['id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at']],
             ],
             'meta' => ['pagination' => ['total', 'count', 'per_page', 'current_page', 'total_pages']],
         ]);
@@ -49,6 +49,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
                 'attributes' => [
                     'id' => $this->getApiUser()->id,
                     'external_id' => $this->getApiUser()->external_id,
+                    'discord_id' => $this->getApiUser()->discord_id,
                     'uuid' => $this->getApiUser()->uuid,
                     'username' => $this->getApiUser()->username,
                     'email' => $this->getApiUser()->email,
@@ -66,6 +67,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
                 'attributes' => [
                     'id' => $user->id,
                     'external_id' => $user->external_id,
+                    'discord_id' => $user->discord_id,
                     'uuid' => $user->uuid,
                     'username' => $user->username,
                     'email' => $user->email,
@@ -92,7 +94,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonCount(2);
         $response->assertJsonStructure([
             'object',
-            'attributes' => ['id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
+            'attributes' => ['id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
         ]);
 
         $response->assertJson([
@@ -100,6 +102,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
             'attributes' => [
                 'id' => $user->id,
                 'external_id' => $user->external_id,
+                'discord_id' => $user->discord_id,
                 'uuid' => $user->uuid,
                 'username' => $user->username,
                 'email' => $user->email,
@@ -128,7 +131,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonStructure([
             'object',
             'attributes' => [
-                'id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at',
+                'id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at',
                 'relationships' => ['servers' => ['object', 'data' => [['object', 'attributes' => []]]]],
             ],
         ]);
@@ -217,7 +220,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonCount(3);
         $response->assertJsonStructure([
             'object',
-            'attributes' => ['id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
+            'attributes' => ['id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
             'meta' => ['resource'],
         ]);
 
@@ -250,7 +253,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
         $response->assertJsonCount(2);
         $response->assertJsonStructure([
             'object',
-            'attributes' => ['id', 'external_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
+            'attributes' => ['id', 'external_id', 'discord_id', 'uuid', 'username', 'email', 'first_name', 'last_name', 'language', 'root_admin', '2fa', 'created_at', 'updated_at'],
         ]);
 
         $this->assertDatabaseHas('users', ['username' => 'new.test.name', 'email' => 'new@emailtest.com']);


### PR DESCRIPTION
Adds the `discord_id` field to the user integration tests.