### PR TITLE
Fix code typo in plugin manager API

### DIFF
--- a/resources/scripts/api/server/plugins/getPlugins.ts
+++ b/resources/scripts/api/server/plugins/getPlugins.ts
@@ -9,5 +9,5 @@ export default async (uuid: string, query: string): Promise<Plugin> => {
         query,
     });
 
-    return data.data || [];
+    return data || [];
 };

--- a/resources/scripts/api/server/plugins/installPlugin.ts
+++ b/resources/scripts/api/server/plugins/installPlugin.ts
@@ -3,5 +3,5 @@ import http from '@/api/http';
 export default async (uuid: string, id: number): Promise<void> => {
     const { data } = await http.post(`/api/client/servers/${uuid}/plugins/install/${id}`);
 
-    return data.data || [];
+    return data || [];
 };


### PR DESCRIPTION
in [`getPlugins.ts`](https://github.com/then77/Jexactyl/blob/develop/resources/scripts/api/server/plugins/getPlugins.ts) and [`installPlugin.ts`](https://github.com/then77/Jexactyl/blob/develop/resources/scripts/api/server/plugins/installPlugin.ts), you should not type `data.data` for the returned response. Just use `data` as its already returned the response data.

```js
return data.data || []; // Will always return []
return data || []; // Should work correctly
```