### PR TITLE
Remove gray background if server already has a background

### DIFF
--- a/resources/scripts/components/dashboard/ServerRow.tsx
+++ b/resources/scripts/components/dashboard/ServerRow.tsx
@@ -89,7 +89,11 @@ export default ({ server, className }: { server: Server; className?: string }) =
             $bg={server.bg}
         >
             <div
-                css={tw`flex flex-wrap py-4 justify-between items-center col-span-12 sm:col-span-5 lg:col-span-6 bg-gray-700 rounded-lg shadow-lg`}
+                className={`${
+                    server.bg
+                        ? 'flex flex-wrap py-4 justify-between items-center col-span-12 sm:col-span-5 lg:col-span-6'
+                        : 'flex flex-wrap py-4 justify-between items-center col-span-12 sm:col-span-5 lg:col-span-6 bg-gray-700 rounded-lg shadow-lg'
+                }`}
             >
                 <p css={tw`px-6 text-2xl font-bold`}>{server.name}</p>
                 <p css={tw`px-6 text-sm text-gray-400 line-clamp-1 text-center`}>


### PR DESCRIPTION
I saw someone on discord complaining about the gray background looking weird when there is a custom background so this just removes the gray background if there is already a custom background
![image](https://github.com/Jexactyl/Jexactyl/assets/66735773/1fa0b9ea-c93e-40e8-bf6b-2de18b27634e)

![image](https://github.com/Jexactyl/Jexactyl/assets/66735773/5d2686ea-c2f0-422e-adfc-7b0a6205d48f)
