### PR TITLE
Fixed mess caused by replacing all 'pterodactyl' by 'Jexactyl'.

### DIFF
--- a/app/Console/Commands/Environment/DatabaseSettingsCommand.php
+++ b/app/Console/Commands/Environment/DatabaseSettingsCommand.php
@@ -56,7 +56,7 @@ class DatabaseSettingsCommand extends Command
         $this->output->note('Using the "root" account for MySQL connections is not only highly frowned upon, it is also not allowed by this application. You\'ll need to have created a MySQL user for this software.');
         $this->variables['DB_USERNAME'] = $this->option('username') ?? $this->ask(
             'Database Username',
-            config('database.connections.mysql.username', 'Jexactyl')
+            config('database.connections.mysql.username', 'jexactyl')
         );
 
         $askForMySQLPassword = true;
@@ -76,7 +76,7 @@ class DatabaseSettingsCommand extends Command
             $this->output->error('Your connection credentials have NOT been saved. You will need to provide valid connection information before proceeding.');
 
             if ($this->confirm('Go back and try again?')) {
-                $this->database->disconnect('_Jexactyl_command_test');
+                $this->database->disconnect('_jexactyl_command_test');
 
                 return $this->handle();
             }
@@ -96,7 +96,7 @@ class DatabaseSettingsCommand extends Command
      */
     private function testMySQLConnection()
     {
-        config()->set('database.connections._Jexactyl_command_test', [
+        config()->set('database.connections._jexactyl_command_test', [
             'driver' => 'mysql',
             'host' => $this->variables['DB_HOST'],
             'port' => $this->variables['DB_PORT'],
@@ -108,6 +108,6 @@ class DatabaseSettingsCommand extends Command
             'strict' => true,
         ]);
 
-        $this->database->connection('_Jexactyl_command_test')->getPdo();
+        $this->database->connection('_jexactyl_command_test')->getPdo();
     }
 }

--- a/app/Console/Commands/InfoCommand.php
+++ b/app/Console/Commands/InfoCommand.php
@@ -30,7 +30,7 @@ class InfoCommand extends Command
             ['Panel Version', $this->config->get('app.version')],
             ['Latest Version', $this->versionService->getPanel()],
             ['Up-to-Date', $this->versionService->isLatestPanel() ? 'Yes' : $this->formatText('No', 'bg=red')],
-            ['Unique Identifier', $this->config->get('Jexactyl.service.author')],
+            ['Unique Identifier', $this->config->get('jexactyl.service.author')],
         ], 'compact');
 
         $this->output->title('Application Configuration');
@@ -45,7 +45,7 @@ class InfoCommand extends Command
             ['Session Driver', $this->config->get('session.driver')],
             ['Filesystem Driver', $this->config->get('filesystems.default')],
             ['Default Theme', $this->config->get('themes.active')],
-            ['Proxies', $this->config->get('trustedproxies.proxies')],
+            ['Proxies', implode(", ", $this->config->get('trustedproxy.proxies'))],
         ], 'compact');
 
         $this->output->title('Database Configuration');

--- a/app/Console/Commands/Node/MakeNodeCommand.php
+++ b/app/Console/Commands/Node/MakeNodeCommand.php
@@ -61,7 +61,7 @@ class MakeNodeCommand extends Command
         $data['upload_size'] = $this->option('uploadSize') ?? $this->ask('Enter the maximum filesize upload', '100');
         $data['daemonListen'] = $this->option('daemonListeningPort') ?? $this->ask('Enter the wings listening port', '8080');
         $data['daemonSFTP'] = $this->option('daemonSFTPPort') ?? $this->ask('Enter the wings SFTP listening port', '2022');
-        $data['daemonBase'] = $this->option('daemonBase') ?? $this->ask('Enter the base folder', '/var/lib/jexactyl/volumes');
+        $data['daemonBase'] = $this->option('daemonBase') ?? $this->ask('Enter the base folder', '/var/lib/pterodactyl/volumes');
 
         $node = $this->creationService->handle($data);
         $this->line('Successfully created a new node on the location ' . $data['location_id'] . ' with the name ' . $data['name'] . ' and has an id of ' . $node->id . '.');

--- a/app/Console/Commands/Node/MakeNodeCommand.php
+++ b/app/Console/Commands/Node/MakeNodeCommand.php
@@ -61,7 +61,7 @@ class MakeNodeCommand extends Command
         $data['upload_size'] = $this->option('uploadSize') ?? $this->ask('Enter the maximum filesize upload', '100');
         $data['daemonListen'] = $this->option('daemonListeningPort') ?? $this->ask('Enter the wings listening port', '8080');
         $data['daemonSFTP'] = $this->option('daemonSFTPPort') ?? $this->ask('Enter the wings SFTP listening port', '2022');
-        $data['daemonBase'] = $this->option('daemonBase') ?? $this->ask('Enter the base folder', '/var/lib/Jexactyl/volumes');
+        $data['daemonBase'] = $this->option('daemonBase') ?? $this->ask('Enter the base folder', '/var/lib/jexactyl/volumes');
 
         $node = $this->creationService->handle($data);
         $this->line('Successfully created a new node on the location ' . $data['location_id'] . ' with the name ' . $data['name'] . ' and has an id of ' . $node->id . '.');

--- a/app/Console/Commands/Schedule/ProcessRunnableCommand.php
+++ b/app/Console/Commands/Schedule/ProcessRunnableCommand.php
@@ -52,7 +52,7 @@ class ProcessRunnableCommand extends Command
      * never throw an exception out, otherwise you'll end up killing the entire run group causing
      * any other schedules to not process correctly.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2609
+     * @see https://github.com/pterodactyl/panel/issues/2609
      */
     protected function processSchedule(Schedule $schedule)
     {

--- a/app/Console/Commands/UpgradeCommand.php
+++ b/app/Console/Commands/UpgradeCommand.php
@@ -173,7 +173,7 @@ class UpgradeCommand extends Command
         });
 
         $this->newLine(2);
-        $this->info('Panel has been successfully upgraded. Please ensure you also update any Wings instances: https://Jexactyl.io/wings/1.0/upgrading.html');
+        $this->info('Panel has been successfully upgraded. Please ensure you also update any Wings instances: https://pterodactyl.io/wings/1.0/upgrading.html');
     }
 
     protected function withProgress(ProgressBar $bar, \Closure $callback)

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -30,7 +30,7 @@ class Handler extends ExceptionHandler
      * resulting in some weird rule names. This string will be parsed out and
      * replaced with 'p_' in the response code.
      */
-    private const Jexactyl_RULE_STRING = 'Jexactyl\_rules\_';
+    private const JEXACTYL_RULE_STRING = 'jexactyl\_rules\_';
 
     /**
      * A list of the exception types that should not be reported.
@@ -133,7 +133,7 @@ class Handler extends ExceptionHandler
         // much as possible at the code level, but there are a lot of spots that do a
         // ton of actions and were written before this bug discovery was made.
         //
-        // @see https://github.com/Jexactyl/panel/pull/1468
+        // @see https://github.com/pteroactyl/panel/pull/1468
         if ($connections->transactionLevel()) {
             $connections->rollBack(0);
         }
@@ -163,7 +163,7 @@ class Handler extends ExceptionHandler
             foreach ($errors as $key => $error) {
                 $meta = [
                     'source_field' => $field,
-                    'rule' => str_replace(self::Jexactyl_RULE_STRING, 'p_', Arr::get(
+                    'rule' => str_replace(self::JEXACTYL_RULE_STRING, 'p_', Arr::get(
                         $codes,
                         str_replace('.', '_', $field) . '.' . $key
                     )),

--- a/app/Exceptions/Solutions/ManifestDoesNotExistSolution.php
+++ b/app/Exceptions/Solutions/ManifestDoesNotExistSolution.php
@@ -19,7 +19,7 @@ class ManifestDoesNotExistSolution implements Solution
     public function getDocumentationLinks(): array
     {
         return [
-            'Docs' => 'https://github.com/Jexactyl/panel/blob/develop/package.json',
+            'Docs' => 'https://github.com/Jexactyl/Jexactyl/blob/develop/package.json',
         ];
     }
 }

--- a/app/Http/Controllers/Admin/Servers/ServerController.php
+++ b/app/Http/Controllers/Admin/Servers/ServerController.php
@@ -31,7 +31,7 @@ class ServerController extends Controller
                 AllowedFilter::exact('owner_id'),
                 AllowedFilter::custom('*', new AdminServerFilter()),
             ])
-            ->paginate(config()->get('Jexactyl.paginate.admin.servers'));
+            ->paginate(config()->get('jexactyl.paginate.admin.servers'));
 
         return $this->view->make('admin.servers.index', ['servers' => $servers]);
     }

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
@@ -118,7 +118,7 @@ class ScheduleController extends ClientApiController
         // Toggle the processing state of the scheduled task when it is enabled or disabled so that an
         // invalid state can be reset without manual database intervention.
         //
-        // @see https://github.com/Jexactyl/panel/issues/2425
+        // @see https://github.com/pterodactyl/panel/issues/2425
         if ($schedule->is_active !== $active) {
             $data['is_processing'] = false;
         }

--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -69,9 +69,9 @@ class ServerInstallController extends Controller
         // If the server successfully installed, fire installed event.
         // This logic allows individually disabling install and reinstall notifications separately.
         $isInitialInstall = is_null($server->installed_at);
-        if ($isInitialInstall && config()->get('Jexactyl.email.send_install_notification', true)) {
+        if ($isInitialInstall && config()->get('jexactyl.email.send_install_notification', true)) {
             $this->eventDispatcher->dispatch(new ServerInstalled($server));
-        } elseif (!$isInitialInstall && config()->get('Jexactyl.email.send_reinstall_notification', true)) {
+        } elseif (!$isInitialInstall && config()->get('jexactyl.email.send_reinstall_notification', true)) {
             $this->eventDispatcher->dispatch(new ServerInstalled($server));
         }
 

--- a/app/Http/Requests/Admin/Jexactyl/AdvancedFormRequest.php
+++ b/app/Http/Requests/Admin/Jexactyl/AdvancedFormRequest.php
@@ -12,27 +12,27 @@ class AdvancedFormRequest extends AdminFormRequest
     public function rules(): array
     {
         return [
-            'Jexactyl:auth:2fa_required' => 'required|integer|in:0,1,2',
+            'jexactyl:auth:2fa_required' => 'required|integer|in:0,1,2',
 
             'recaptcha:enabled' => 'required|in:true,false',
             'recaptcha:secret_key' => 'required|string|max:191',
             'recaptcha:website_key' => 'required|string|max:191',
-            'Jexactyl:guzzle:timeout' => 'required|integer|between:1,60',
-            'Jexactyl:guzzle:connect_timeout' => 'required|integer|between:1,60',
+            'jexactyl:guzzle:timeout' => 'required|integer|between:1,60',
+            'jexactyl:guzzle:connect_timeout' => 'required|integer|between:1,60',
 
-            'Jexactyl:client_features:allocations:enabled' => 'required|in:true,false',
-            'Jexactyl:client_features:allocations:range_start' => [
+            'jexactyl:client_features:allocations:enabled' => 'required|in:true,false',
+            'jexactyl:client_features:allocations:range_start' => [
                 'nullable',
-                'required_if:Jexactyl:client_features:allocations:enabled,true',
+                'required_if:jexactyl:client_features:allocations:enabled,true',
                 'integer',
                 'between:1024,65535',
             ],
-            'Jexactyl:client_features:allocations:range_end' => [
+            'jexactyl:client_features:allocations:range_end' => [
                 'nullable',
-                'required_if:Jexactyl:client_features:allocations:enabled,true',
+                'required_if:jexactyl:client_features:allocations:enabled,true',
                 'integer',
                 'between:1024,65535',
-                'gt:Jexactyl:client_features:allocations:range_start',
+                'gt:jexactyl:client_features:allocations:range_start',
             ],
         ];
     }
@@ -43,11 +43,11 @@ class AdvancedFormRequest extends AdminFormRequest
             'recaptcha:enabled' => 'reCAPTCHA Enabled',
             'recaptcha:secret_key' => 'reCAPTCHA Secret Key',
             'recaptcha:website_key' => 'reCAPTCHA Website Key',
-            'Jexactyl:guzzle:timeout' => 'HTTP Request Timeout',
-            'Jexactyl:guzzle:connect_timeout' => 'HTTP Connection Timeout',
-            'Jexactyl:client_features:allocations:enabled' => 'Auto Create Allocations Enabled',
-            'Jexactyl:client_features:allocations:range_start' => 'Starting Port',
-            'Jexactyl:client_features:allocations:range_end' => 'Ending Port',
+            'jexactyl:guzzle:timeout' => 'HTTP Request Timeout',
+            'jexactyl:guzzle:connect_timeout' => 'HTTP Connection Timeout',
+            'jexactyl:client_features:allocations:enabled' => 'Auto Create Allocations Enabled',
+            'jexactyl:client_features:allocations:range_start' => 'Starting Port',
+            'jexactyl:client_features:allocations:range_end' => 'Ending Port',
         ];
     }
 }

--- a/app/Http/Requests/Api/Application/Servers/UpdateServerBuildConfigurationRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/UpdateServerBuildConfigurationRequest.php
@@ -29,7 +29,7 @@ class UpdateServerBuildConfigurationRequest extends ServerWriteRequest
             // Legacy rules to maintain backwards compatable API support without requiring
             // a major version bump.
             //
-            // @see https://github.com/Jexactyl/panel/issues/1500
+            // @see https://github.com/pterodactyl/panel/issues/1500
             'memory' => $this->requiredToOptional('memory', $rules['memory']),
             'swap' => $this->requiredToOptional('swap', $rules['swap']),
             'io' => $this->requiredToOptional('io', $rules['io']),
@@ -95,7 +95,7 @@ class UpdateServerBuildConfigurationRequest extends ServerWriteRequest
      * compatability with the old API endpoint while also supporting a more correct API
      * call.
      *
-     * @see https://github.com/Jexactyl/panel/issues/1500
+     * @see https://github.com/pterodactyl/panel/issues/1500
      */
     protected function requiredToOptional(string $field, array $rules, bool $limits = false): array
     {

--- a/app/Models/Mount.php
+++ b/app/Models/Mount.php
@@ -80,8 +80,8 @@ class Mount extends Model
      * Blacklisted source paths.
      */
     public static $invalidSourcePaths = [
-        '/etc/Jexactyl',
-        '/var/lib/Jexactyl/volumes',
+        '/etc/jexactyl',
+        '/var/lib/jexactyl/volumes',
         '/srv/daemon-data',
     ];
 

--- a/app/Models/Mount.php
+++ b/app/Models/Mount.php
@@ -80,8 +80,8 @@ class Mount extends Model
      * Blacklisted source paths.
      */
     public static $invalidSourcePaths = [
-        '/etc/jexactyl',
-        '/var/lib/jexactyl/volumes',
+        '/etc/pterodactyl',
+        '/var/lib/pterodactyl/volumes',
         '/srv/daemon-data',
     ];
 

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -121,7 +121,7 @@ class Node extends Model
         'behind_proxy' => false,
         'memory_overallocate' => 0,
         'disk_overallocate' => 0,
-        'daemonBase' => '/var/lib/Jexactyl/volumes',
+        'daemonBase' => '/var/lib/jexactyl/volumes',
         'daemonSFTP' => 2022,
         'daemonListen' => 8080,
         'maintenance_mode' => false,

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -121,7 +121,7 @@ class Node extends Model
         'behind_proxy' => false,
         'memory_overallocate' => 0,
         'disk_overallocate' => 0,
-        'daemonBase' => '/var/lib/jexactyl/volumes',
+        'daemonBase' => '/var/lib/pterodactyl/volumes',
         'daemonSFTP' => 2022,
         'daemonListen' => 8080,
         'maintenance_mode' => false,

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -284,7 +284,7 @@ class Server extends Model
                 // would actually return all the variables and their values for _all_ servers using that egg,
                 // rather than only the server for this model.
                 //
-                // @see https://github.com/Jexactyl/panel/issues/2250
+                // @see https://github.com/pterodactyl/panel/issues/2250
                 $join->on('server_variables.variable_id', 'egg_variables.id')
                     ->where('server_variables.server_id', $this->id);
             });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,7 +31,7 @@ class AppServiceProvider extends ServiceProvider
         // this should just work with the proxy logic, but there are a lot of cases where it
         // doesn't, and it triggers a lot of support requests, so lets just head it off here.
         //
-        // @see https://github.com/Jexactyl/panel/issues/3623
+        // @see https://github.com/pterodactyl/panel/issues/3623
         if (Str::startsWith(config('app.url') ?? '', 'https://')) {
             URL::forceScheme('https');
         }

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -25,12 +25,12 @@ class SettingsServiceProvider extends ServiceProvider
         'recaptcha:secret_key',
         'recaptcha:website_key',
         'theme:user:background',
-        'Jexactyl:guzzle:timeout',
-        'Jexactyl:auth:2fa_required',
-        'Jexactyl:guzzle:connect_timeout',
-        'Jexactyl:client_features:allocations:enabled',
-        'Jexactyl:client_features:allocations:range_end',
-        'Jexactyl:client_features:allocations:range_start',
+        'jexactyl:guzzle:timeout',
+        'jexactyl:auth:2fa_required',
+        'jexactyl:guzzle:connect_timeout',
+        'jexactyl:client_features:allocations:enabled',
+        'jexactyl:client_features:allocations:range_end',
+        'jexactyl:client_features:allocations:range_start',
     ];
 
     /**

--- a/app/Services/Eggs/EggConfigurationService.php
+++ b/app/Services/Eggs/EggConfigurationService.php
@@ -92,7 +92,7 @@ class EggConfigurationService
             // of egg creation/update, but it isn't so this check will at least prevent a
             // 500 error which would crash the entire Wings boot process.
             //
-            // @see https://github.com/Jexactyl/panel/issues/3055
+            // @see https://github.com/pterodactyl/panel/issues/3055
             if (!is_object($data) || !isset($data->find)) {
                 continue;
             }

--- a/app/Services/Eggs/EggCreationService.php
+++ b/app/Services/Eggs/EggCreationService.php
@@ -40,7 +40,7 @@ class EggCreationService
 
         return $this->repository->create(array_merge($data, [
             'uuid' => Uuid::uuid4()->toString(),
-            'author' => $this->config->get('Jexactyl.service.author'),
+            'author' => $this->config->get('jexactyl.service.author'),
         ]), true, true);
     }
 }

--- a/app/Services/Helpers/SoftwareVersionService.php
+++ b/app/Services/Helpers/SoftwareVersionService.php
@@ -11,7 +11,7 @@ use Jexactyl\Exceptions\Service\Helper\CdnVersionFetchingException;
 
 class SoftwareVersionService
 {
-    public const VERSION_CACHE_KEY = 'Jexactyl:versioning_data';
+    public const VERSION_CACHE_KEY = 'jexactyl:versioning_data';
 
     private static array $result;
 
@@ -46,7 +46,7 @@ class SoftwareVersionService
      */
     public function getDiscord(): string
     {
-        return Arr::get(self::$result, 'discord') ?? 'https://Jexactyl.io/discord';
+        return Arr::get(self::$result, 'discord') ?? 'https://discord.gg/qttGR4Z5Pk';
     }
 
     /**

--- a/app/Services/Nodes/NodeUpdateService.php
+++ b/app/Services/Nodes/NodeUpdateService.php
@@ -50,7 +50,7 @@ class NodeUpdateService
                 // This makes more sense anyways, because only the Panel uses the FQDN for connecting, the
                 // node doesn't actually care about this.
                 //
-                // @see https://github.com/Jexactyl/panel/issues/1931
+                // @see https://github.com/pterodactyl/panel/issues/1931
                 $node->fqdn = $updated->fqdn;
 
                 $this->configurationRepository->setNode($node)->update($updated);
@@ -64,7 +64,7 @@ class NodeUpdateService
                 // This avoids issues with proxies such as Cloudflare which will see Wings as offline and then
                 // inject their own response pages, causing this logic to get fucked up.
                 //
-                // @see https://github.com/Jexactyl/panel/issues/2712
+                // @see https://github.com/pterodactyl/panel/issues/2712
                 return [$updated, true];
             }
 

--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -75,7 +75,7 @@ class ProcessScheduleService
             // When using dispatchNow the RunTaskJob::failed() function is not called automatically
             // so we need to manually trigger it and then continue with the exception throw.
             //
-            // @see https://github.com/Jexactyl/panel/issues/2550
+            // @see https://github.com/pterodactyl/panel/issues/2550
             try {
                 $this->dispatcher->dispatchNow($job);
             } catch (\Exception $exception) {

--- a/app/Services/Servers/ServerDeletionService.php
+++ b/app/Services/Servers/ServerDeletionService.php
@@ -84,7 +84,7 @@ class ServerDeletionService
                     // the host instance, but we couldn't delete it anyways so not sure how we would
                     // handle this better anyways.
                     //
-                    // @see https://github.com/Jexactyl/panel/issues/2085
+                    // @see https://github.com/pterodactyl/panel/issues/2085
                     $database->delete();
 
                     Log::warning($exception);

--- a/app/Services/Users/ToggleTwoFactorService.php
+++ b/app/Services/Users/ToggleTwoFactorService.php
@@ -39,7 +39,7 @@ class ToggleTwoFactorService
     {
         $secret = $this->encrypter->decrypt($user->totp_secret);
 
-        $isValidToken = $this->google2FA->verifyKey($secret, $token, config()->get('Jexactyl.auth.2fa.window'));
+        $isValidToken = $this->google2FA->verifyKey($secret, $token, config()->get('jexactyl.auth.2fa.window'));
 
         if (!$isValidToken) {
             throw new TwoFactorAuthenticationTokenInvalid();

--- a/app/Services/Users/TwoFactorSetupService.php
+++ b/app/Services/Users/TwoFactorSetupService.php
@@ -33,7 +33,7 @@ class TwoFactorSetupService
     {
         $secret = '';
         try {
-            for ($i = 0; $i < $this->config->get('Jexactyl.auth.2fa.bytes', 16); ++$i) {
+            for ($i = 0; $i < $this->config->get('jexactyl.auth.2fa.bytes', 16); ++$i) {
                 $secret .= substr(self::VALID_BASE32_CHARACTERS, random_int(0, 31), 1);
             }
         } catch (\Exception $exception) {

--- a/config/cache.php
+++ b/config/cache.php
@@ -99,5 +99,5 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'Jexactyl'), '_') . '_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'jexactyl'), '_') . '_cache_'),
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -40,7 +40,7 @@ return [
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'panel'),
-            'username' => env('DB_USERNAME', 'Jexactyl'),
+            'username' => env('DB_USERNAME', 'jexactyl'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
@@ -88,7 +88,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'Jexactyl'), '_') . '_database_'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'jexactyl'), '_') . '_database_'),
         ],
 
         'default' => [

--- a/config/jexactyl.php
+++ b/config/jexactyl.php
@@ -105,19 +105,19 @@ return [
 
     'client_features' => [
         'databases' => [
-            'enabled' => env('Jexactyl_CLIENT_DATABASES_ENABLED', true),
-            'allow_random' => env('Jexactyl_CLIENT_DATABASES_ALLOW_RANDOM', true),
+            'enabled' => env('JEXACTYL_CLIENT_DATABASES_ENABLED', true),
+            'allow_random' => env('JEXACTYL_CLIENT_DATABASES_ALLOW_RANDOM', true),
         ],
 
         'schedules' => [
             // The total number of tasks that can exist for any given schedule at once.
-            'per_schedule_task_limit' => env('Jexactyl_PER_SCHEDULE_TASK_LIMIT', 10),
+            'per_schedule_task_limit' => env('JEXACTYL_PER_SCHEDULE_TASK_LIMIT', 10),
         ],
 
         'allocations' => [
-            'enabled' => env('Jexactyl_CLIENT_ALLOCATIONS_ENABLED', true),
-            'range_start' => env('Jexactyl_CLIENT_ALLOCATIONS_RANGE_START'),
-            'range_end' => env('Jexactyl_CLIENT_ALLOCATIONS_RANGE_END'),
+            'enabled' => env('JEXACTYL_CLIENT_ALLOCATIONS_ENABLED', true),
+            'range_start' => env('JEXACTYL_CLIENT_ALLOCATIONS_RANGE_START'),
+            'range_end' => env('JEXACTYL_CLIENT_ALLOCATIONS_RANGE_END'),
         ],
     ],
 
@@ -130,7 +130,7 @@ return [
     */
 
     'files' => [
-        'max_edit_size' => env('Jexactyl_FILES_MAX_EDIT_SIZE', 1024 * 1024 * 4),
+        'max_edit_size' => env('JEXACTYL_FILES_MAX_EDIT_SIZE', 1024 * 1024 * 4),
     ],
 
     /*
@@ -160,7 +160,7 @@ return [
     */
 
     'assets' => [
-        'use_hash' => env('Jexactyl_USE_ASSET_HASH', false),
+        'use_hash' => env('JEXACTYL_USE_ASSET_HASH', false),
     ],
 
     /*
@@ -173,8 +173,8 @@ return [
 
     'email' => [
         // Should an email be sent to a server owner once their server has completed it's first install process?
-        'send_install_notification' => env('Jexactyl_SEND_INSTALL_NOTIFICATION', true),
+        'send_install_notification' => env('JEXACTYL_SEND_INSTALL_NOTIFICATION', true),
         // Should an email be sent to a server owner whenever their server is reinstalled?
-        'send_reinstall_notification' => env('Jexactyl_SEND_REINSTALL_NOTIFICATION', true),
+        'send_reinstall_notification' => env('JEXACTYL_SEND_REINSTALL_NOTIFICATION', true),
     ],
 ];

--- a/config/session.php
+++ b/config/session.php
@@ -127,7 +127,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'Jexactyl'), '_') . '_session'
+        Str::slug(env('APP_NAME', 'jexactyl'), '_') . '_session'
     ),
 
     /*

--- a/resources/scripts/components/auth/DiscordFormContainer.tsx
+++ b/resources/scripts/components/auth/DiscordFormContainer.tsx
@@ -37,7 +37,7 @@ const DiscordFormContainer = ({ children }: { children: React.ReactNode }) => {
                 </div>
                 <p css={tw`text-neutral-500 text-xs mt-6 sm:float-left`}>
                     &copy; <a href={'https://jexactyl.com'}>Jexactyl,</a> built on{' '}
-                    <a href={'https://jexactyl.com'}>Jexactyl.</a>
+                    <a href={'https://pterodactyl.io'}>Pterodactyl.</a>
                 </p>
                 <p css={tw`text-neutral-500 text-xs mt-6 sm:float-right`}>
                     <a href={'https://jexactyl.com'}> Site </a>

--- a/resources/scripts/components/auth/LoginFormContainer.tsx
+++ b/resources/scripts/components/auth/LoginFormContainer.tsx
@@ -46,7 +46,7 @@ export default forwardRef<HTMLFormElement, Props>(({ title, ...props }, ref) => 
             </Form>
             <p css={tw`text-neutral-500 text-xs mt-6 sm:float-left`}>
                 &copy; <a href={'https://jexactyl.com'}>Jexactyl,</a> built on{' '}
-                <a href={'https://jexactyl.com'}>Jexactyl.</a>
+                <a href={'https://pterodactyl.io'}>Pterodactyl.</a>
             </p>
             <p css={tw`text-neutral-500 text-xs mt-6 sm:float-right`}>
                 <a href={'https://jexactyl.com'}> Site </a>

--- a/resources/scripts/components/elements/PageContentBlock.tsx
+++ b/resources/scripts/components/elements/PageContentBlock.tsx
@@ -49,7 +49,7 @@ const PageContentBlock: React.FC<PageContentBlockProps> = ({
                 <ContentContainer css={tw`text-sm text-center my-4 pb-8`}>
                     <p css={tw`text-neutral-500 sm:float-left`}>
                         &copy; <a href={'https://jexactyl.com'}>Jexactyl,</a> built on{' '}
-                        <a href={'https://jexactyl.com'}>Jexactyl.</a>
+                        <a href={'https://pterodactyl.io'}>Pterodactyl.</a>
                     </p>
                     <p css={tw`text-neutral-500 sm:float-right`}>
                         <a href={'https://jexactyl.com'}> Site </a>

--- a/resources/views/admin/jexactyl/advanced.blade.php
+++ b/resources/views/admin/jexactyl/advanced.blade.php
@@ -9,7 +9,7 @@
     <h1>Advanced<small>Configure advanced settings for the Panel.</small></h1>
     <ol class="breadcrumb">
         <li><a href="{{ route('admin.index') }}">Admin</a></li>
-        <li class="active">Jexactyl</li>
+        <li class="active">jexactyl</li>
     </ol>
 @endsection
 
@@ -29,16 +29,16 @@
                                     <div>
                                         <div class="btn-group" data-toggle="buttons">
                                             @php
-                                                $level = old('Jexactyl:auth:2fa_required', config('jexactyl.auth.2fa_required'));
+                                                $level = old('jexactyl:auth:2fa_required', config('jexactyl.auth.2fa_required'));
                                             @endphp
                                             <label class="btn btn-primary @if ($level == 0) active @endif">
-                                                <input type="radio" name="Jexactyl:auth:2fa_required" autocomplete="off" value="0" @if ($level == 0) checked @endif> Not Required
+                                                <input type="radio" name="jexactyl:auth:2fa_required" autocomplete="off" value="0" @if ($level == 0) checked @endif> Not Required
                                             </label>
                                             <label class="btn btn-primary @if ($level == 1) active @endif">
-                                                <input type="radio" name="Jexactyl:auth:2fa_required" autocomplete="off" value="1" @if ($level == 1) checked @endif> Admin Only
+                                                <input type="radio" name="jexactyl:auth:2fa_required" autocomplete="off" value="1" @if ($level == 1) checked @endif> Admin Only
                                             </label>
                                             <label class="btn btn-primary @if ($level == 2) active @endif">
-                                                <input type="radio" name="Jexactyl:auth:2fa_required" autocomplete="off" value="2" @if ($level == 2) checked @endif> All Users
+                                                <input type="radio" name="jexactyl:auth:2fa_required" autocomplete="off" value="2" @if ($level == 2) checked @endif> All Users
                                             </label>
                                         </div>
                                         <p class="text-muted"><small>If enabled, any account falling into the selected grouping will be required to have 2-Factor authentication enabled to use the Panel.</small></p>
@@ -101,14 +101,14 @@
                                 <div class="form-group col-md-6">
                                     <label class="control-label">Connection Timeout</label>
                                     <div>
-                                        <input type="number" required class="form-control" name="Jexactyl:guzzle:connect_timeout" value="{{ old('Jexactyl:guzzle:connect_timeout', config('jexactyl.guzzle.connect_timeout')) }}">
+                                        <input type="number" required class="form-control" name="jexactyl:guzzle:connect_timeout" value="{{ old('jexactyl:guzzle:connect_timeout', config('jexactyl.guzzle.connect_timeout')) }}">
                                         <p class="text-muted small">The amount of time in seconds to wait for a connection to be opened before throwing an error.</p>
                                     </div>
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label class="control-label">Request Timeout</label>
                                     <div>
-                                        <input type="number" required class="form-control" name="Jexactyl:guzzle:timeout" value="{{ old('Jexactyl:guzzle:timeout', config('jexactyl.guzzle.timeout')) }}">
+                                        <input type="number" required class="form-control" name="jexactyl:guzzle:timeout" value="{{ old('jexactyl:guzzle:timeout', config('jexactyl.guzzle.timeout')) }}">
                                         <p class="text-muted small">The amount of time in seconds to wait for a request to be completed before throwing an error.</p>
                                     </div>
                                 </div>
@@ -124,9 +124,9 @@
                                 <div class="form-group col-md-4">
                                     <label class="control-label">Status</label>
                                     <div>
-                                        <select class="form-control" name="Jexactyl:client_features:allocations:enabled">
+                                        <select class="form-control" name="jexactyl:client_features:allocations:enabled">
                                             <option value="false">Disabled</option>
-                                            <option value="true" @if(old('Jexactyl:client_features:allocations:enabled', config('jexactyl.client_features.allocations.enabled'))) selected @endif>Enabled</option>
+                                            <option value="true" @if(old('jexactyl:client_features:allocations:enabled', config('jexactyl.client_features.allocations.enabled'))) selected @endif>Enabled</option>
                                         </select>
                                         <p class="text-muted small">If enabled users will have the option to automatically create new allocations for their server via the frontend.</p>
                                     </div>
@@ -134,14 +134,14 @@
                                 <div class="form-group col-md-4">
                                     <label class="control-label">Starting Port</label>
                                     <div>
-                                        <input type="number" class="form-control" name="Jexactyl:client_features:allocations:range_start" value="{{ old('Jexactyl:client_features:allocations:range_start', config('jexactyl.client_features.allocations.range_start')) }}">
+                                        <input type="number" class="form-control" name="jexactyl:client_features:allocations:range_start" value="{{ old('jexactyl:client_features:allocations:range_start', config('jexactyl.client_features.allocations.range_start')) }}">
                                         <p class="text-muted small">The starting port in the range that can be automatically allocated.</p>
                                     </div>
                                 </div>
                                 <div class="form-group col-md-4">
                                     <label class="control-label">Ending Port</label>
                                     <div>
-                                        <input type="number" class="form-control" name="Jexactyl:client_features:allocations:range_end" value="{{ old('Jexactyl:client_features:allocations:range_end', config('jexactyl.client_features.allocations.range_end')) }}">
+                                        <input type="number" class="form-control" name="jexactyl:client_features:allocations:range_end" value="{{ old('jexactyl:client_features:allocations:range_end', config('jexactyl.client_features.allocations.range_end')) }}">
                                         <p class="text-muted small">The ending port in the range that can be automatically allocated.</p>
                                     </div>
                                 </div>

--- a/resources/views/admin/nodes/view/configuration.blade.php
+++ b/resources/views/admin/nodes/view/configuration.blade.php
@@ -38,7 +38,7 @@
                 <pre class="no-margin">{{ $node->getYamlConfiguration() }}</pre>
             </div>
             <div class="box-footer">
-                <p class="no-margin">This file should be placed in your daemon's root directory (usually <code>/etc/jexactyl</code>) in a file called <code>config.yml</code>.</p>
+                <p class="no-margin">This file should be placed in your daemon's root directory (usually <code>/etc/pterodactyl</code>) in a file called <code>config.yml</code>.</p>
             </div>
         </div>
     </div>

--- a/resources/views/admin/nodes/view/configuration.blade.php
+++ b/resources/views/admin/nodes/view/configuration.blade.php
@@ -38,7 +38,7 @@
                 <pre class="no-margin">{{ $node->getYamlConfiguration() }}</pre>
             </div>
             <div class="box-footer">
-                <p class="no-margin">This file should be placed in your daemon's root directory (usually <code>/etc/pterodactyl</code>) in a file called <code>config.yml</code>.</p>
+                <p class="no-margin">This file should be placed in your daemon's root directory (usually <code>/etc/jexactyl</code>) in a file called <code>config.yml</code>.</p>
             </div>
         </div>
     </div>
@@ -73,7 +73,7 @@
             swal({
                 type: 'success',
                 title: 'Token created.',
-                text: '<p>To auto-configure your node run the following command:<br /><small><pre>cd /etc/pterodactyl && sudo wings configure --panel-url {{ config('app.url') }} --token ' + data.token + ' --node ' + data.node + '{{ config('app.debug') ? ' --allow-insecure' : '' }}</pre></small></p>',
+                text: '<p>To auto-configure your node run the following command:<br /><small><pre>cd /etc/jexactyl && sudo wings configure --panel-url {{ config('app.url') }} --token ' + data.token + ' --node ' + data.node + '{{ config('app.debug') ? ' --allow-insecure' : '' }}</pre></small></p>',
                 html: true
             })
         }).fail(function () {

--- a/tests/Integration/Api/Client/ApiKeyControllerTest.php
+++ b/tests/Integration/Api/Client/ApiKeyControllerTest.php
@@ -99,8 +99,8 @@ class ApiKeyControllerTest extends ClientApiIntegrationTestCase
      * Test that no more than 25 API keys can exist at any one time for an account. This prevents
      * a DoS attack vector against the panel.
      *
-     * @see https://github.com/Jexactyl/panel/security/advisories/GHSA-pjmh-7xfm-r4x9
-     * @see https://github.com/Jexactyl/panel/issues/4394
+     * @see https://github.com/pterodactyl/panel/security/advisories/GHSA-pjmh-7xfm-r4x9
+     * @see https://github.com/pterodactyl/panel/issues/4394
      */
     public function testApiKeyLimitIsApplied()
     {
@@ -122,7 +122,7 @@ class ApiKeyControllerTest extends ClientApiIntegrationTestCase
     /**
      * Test that a bad request results in a validation error being returned by the API.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2457
+     * @see https://github.com/pterodactyl/panel/issues/2457
      */
     public function testValidationErrorIsReturnedForBadRequests()
     {

--- a/tests/Integration/Api/Client/Server/Allocation/CreateNewAllocationTest.php
+++ b/tests/Integration/Api/Client/Server/Allocation/CreateNewAllocationTest.php
@@ -16,9 +16,9 @@ class CreateNewAllocationTest extends ClientApiIntegrationTestCase
     {
         parent::setUp();
 
-        config()->set('Jexactyl.client_features.allocations.enabled', true);
-        config()->set('Jexactyl.client_features.allocations.range_start', 5000);
-        config()->set('Jexactyl.client_features.allocations.range_end', 5050);
+        config()->set('jexactyl.client_features.allocations.enabled', true);
+        config()->set('jexactyl.client_features.allocations.range_start', 5000);
+        config()->set('jexactyl.client_features.allocations.range_end', 5050);
     }
 
     /**
@@ -59,7 +59,7 @@ class CreateNewAllocationTest extends ClientApiIntegrationTestCase
      */
     public function testAllocationCannotBeCreatedIfNotEnabled()
     {
-        config()->set('Jexactyl.client_features.allocations.enabled', false);
+        config()->set('jexactyl.client_features.allocations.enabled', false);
 
         /** @var \Jexactyl\Models\Server $server */
         [$user, $server] = $this->generateTestAccount();

--- a/tests/Integration/Api/Client/Server/Schedule/UpdateServerScheduleTest.php
+++ b/tests/Integration/Api/Client/Server/Schedule/UpdateServerScheduleTest.php
@@ -83,7 +83,7 @@ class UpdateServerScheduleTest extends ClientApiIntegrationTestCase
      * Test that the "is_processing" field gets reset to false when the schedule is enabled
      * or disabled so that an invalid state can be more easily fixed.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2425
+     * @see https://github.com/pterodactyl/panel/issues/2425
      */
     public function testScheduleIsProcessingIsSetToFalseWhenActiveStateChanges()
     {

--- a/tests/Integration/Api/Client/Server/ScheduleTask/CreateServerScheduleTaskTest.php
+++ b/tests/Integration/Api/Client/Server/ScheduleTask/CreateServerScheduleTaskTest.php
@@ -119,7 +119,7 @@ class CreateServerScheduleTaskTest extends ClientApiIntegrationTestCase
      */
     public function testErrorIsReturnedIfTooManyTasksExistForSchedule()
     {
-        config()->set('Jexactyl.client_features.schedules.per_schedule_task_limit', 2);
+        config()->set('jexactyl.client_features.schedules.per_schedule_task_limit', 2);
 
         [$user, $server] = $this->generateTestAccount();
 

--- a/tests/Integration/Api/Client/Server/Startup/UpdateStartupVariableTest.php
+++ b/tests/Integration/Api/Client/Server/Startup/UpdateStartupVariableTest.php
@@ -114,7 +114,7 @@ class UpdateStartupVariableTest extends ClientApiIntegrationTestCase
      * Test that an egg variable with a validation rule of 'nullable|string' works if no value
      * is passed through in the request.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2433
+     * @see https://github.com/pterodactyl/panel/issues/2433
      */
     public function testEggVariableWithNullableStringIsNotRequired()
     {

--- a/tests/Integration/Api/Client/Server/Subuser/DeleteSubuserTest.php
+++ b/tests/Integration/Api/Client/Server/Subuser/DeleteSubuserTest.php
@@ -20,7 +20,7 @@ class DeleteSubuserTest extends ClientApiIntegrationTestCase
      * it to an integer. Then, in the deep API middlewares you would end up trying to load a user
      * with an ID of 12, which may or may not exist and be wrongly assigned to the model object.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2359
+     * @see https://github.com/pterodactyl/panel/issues/2359
      */
     public function testCorrectSubuserIsDeletedFromServer()
     {

--- a/tests/Integration/Api/Client/TwoFactorControllerTest.php
+++ b/tests/Integration/Api/Client/TwoFactorControllerTest.php
@@ -105,7 +105,7 @@ class TwoFactorControllerTest extends ClientApiIntegrationTestCase
         // Ensure the recovery tokens that were created include a "created_at" timestamp
         // value on them.
         //
-        // @see https://github.com/Jexactyl/panel/issues/3163
+        // @see https://github.com/pterodactyl/panel/issues/3163
         $this->assertNotNull($tokens[0]->created_at);
 
         $tokens = $tokens->pluck('token')->toArray();

--- a/tests/Integration/Http/Controllers/Admin/UserControllerTest.php
+++ b/tests/Integration/Http/Controllers/Admin/UserControllerTest.php
@@ -17,7 +17,7 @@ class UserControllerTest extends IntegrationTestCase
      * data with the number of servers they are assigned to, and the number of servers they
      * are a subuser of.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2469
+     * @see https://github.com/pterodactyl/panel/issues/2469
      */
     public function testIndexReturnsExpectedData()
     {

--- a/tests/Integration/Jobs/Schedule/RunTaskJobTest.php
+++ b/tests/Integration/Jobs/Schedule/RunTaskJobTest.php
@@ -148,7 +148,7 @@ class RunTaskJobTest extends IntegrationTestCase
     /**
      * Test that a schedule is not executed if the server is suspended.
      *
-     * @see https://github.com/Jexactyl/panel/issues/4008
+     * @see https://github.com/pterodactyl/panel/issues/4008
      */
     public function testTaskIsNotRunIfServerIsSuspended()
     {

--- a/tests/Integration/Services/Allocations/FindAssignableAllocationServiceTest.php
+++ b/tests/Integration/Services/Allocations/FindAssignableAllocationServiceTest.php
@@ -17,9 +17,9 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        config()->set('Jexactyl.client_features.allocations.enabled', true);
-        config()->set('Jexactyl.client_features.allocations.range_start', 0);
-        config()->set('Jexactyl.client_features.allocations.range_end', 0);
+        config()->set('jexactyl.client_features.allocations.enabled', true);
+        config()->set('jexactyl.client_features.allocations.range_start', 0);
+        config()->set('jexactyl.client_features.allocations.range_end', 0);
     }
 
     /**
@@ -50,8 +50,8 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
     public function testNewAllocationIsCreatedIfOneIsNotFound()
     {
         $server = $this->createServerModel();
-        config()->set('Jexactyl.client_features.allocations.range_start', 5000);
-        config()->set('Jexactyl.client_features.allocations.range_end', 5005);
+        config()->set('jexactyl.client_features.allocations.range_start', 5000);
+        config()->set('jexactyl.client_features.allocations.range_end', 5005);
 
         $response = $this->getService()->handle($server);
         $this->assertSame($server->id, $response->server_id);
@@ -69,8 +69,8 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
         $server = $this->createServerModel();
         $server2 = $this->createServerModel(['node_id' => $server->node_id]);
 
-        config()->set('Jexactyl.client_features.allocations.range_start', 5000);
-        config()->set('Jexactyl.client_features.allocations.range_end', 5001);
+        config()->set('jexactyl.client_features.allocations.range_start', 5000);
+        config()->set('jexactyl.client_features.allocations.range_end', 5001);
 
         Allocation::factory()->create([
             'server_id' => $server2->id,
@@ -87,8 +87,8 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
     {
         $server = $this->createServerModel();
         $server2 = $this->createServerModel(['node_id' => $server->node_id]);
-        config()->set('Jexactyl.client_features.allocations.range_start', 5000);
-        config()->set('Jexactyl.client_features.allocations.range_end', 5005);
+        config()->set('jexactyl.client_features.allocations.range_start', 5000);
+        config()->set('jexactyl.client_features.allocations.range_end', 5005);
 
         for ($i = 5000; $i <= 5005; ++$i) {
             Allocation::factory()->create([
@@ -134,8 +134,8 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
     public function testExceptionIsThrownIfStartOrEndRangeIsNotNumeric()
     {
         $server = $this->createServerModel();
-        config()->set('Jexactyl.client_features.allocations.range_start', 'hodor');
-        config()->set('Jexactyl.client_features.allocations.range_end', 10);
+        config()->set('jexactyl.client_features.allocations.range_start', 'hodor');
+        config()->set('jexactyl.client_features.allocations.range_end', 10);
 
         try {
             $this->getService()->handle($server);
@@ -145,8 +145,8 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
             $this->assertSame('Expected an integerish value. Got: string', $exception->getMessage());
         }
 
-        config()->set('Jexactyl.client_features.allocations.range_start', 10);
-        config()->set('Jexactyl.client_features.allocations.range_end', 'hodor');
+        config()->set('jexactyl.client_features.allocations.range_start', 10);
+        config()->set('jexactyl.client_features.allocations.range_end', 'hodor');
 
         try {
             $this->getService()->handle($server);
@@ -159,7 +159,7 @@ class FindAssignableAllocationServiceTest extends IntegrationTestCase
 
     public function testExceptionIsThrownIfFeatureIsNotEnabled()
     {
-        config()->set('Jexactyl.client_features.allocations.enabled', false);
+        config()->set('jexactyl.client_features.allocations.enabled', false);
         $server = $this->createServerModel();
 
         $this->expectException(AutoAllocationNotEnabledException::class);

--- a/tests/Integration/Services/Databases/DatabaseManagementServiceTest.php
+++ b/tests/Integration/Services/Databases/DatabaseManagementServiceTest.php
@@ -23,7 +23,7 @@ class DatabaseManagementServiceTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        config()->set('Jexactyl.client_features.databases.enabled', true);
+        config()->set('jexactyl.client_features.databases.enabled', true);
 
         $this->repository = $this->mock(DatabaseRepository::class);
     }
@@ -43,7 +43,7 @@ class DatabaseManagementServiceTest extends IntegrationTestCase
      */
     public function testExceptionIsThrownIfClientDatabasesAreNotEnabled()
     {
-        config()->set('Jexactyl.client_features.databases.enabled', false);
+        config()->set('jexactyl.client_features.databases.enabled', false);
 
         $this->expectException(DatabaseClientFeatureNotEnabledException::class);
 

--- a/tests/Integration/Services/Databases/DeployServerDatabaseServiceTest.php
+++ b/tests/Integration/Services/Databases/DeployServerDatabaseServiceTest.php
@@ -31,7 +31,7 @@ class DeployServerDatabaseServiceTest extends IntegrationTestCase
      */
     protected function tearDown(): void
     {
-        config()->set('Jexactyl.client_features.databases.allow_random', true);
+        config()->set('jexactyl.client_features.databases.allow_random', true);
 
         Database::query()->delete();
         DatabaseHost::query()->delete();
@@ -64,7 +64,7 @@ class DeployServerDatabaseServiceTest extends IntegrationTestCase
         $node = Node::factory()->create(['location_id' => $server->location->id]);
         DatabaseHost::factory()->create(['node_id' => $node->id]);
 
-        config()->set('Jexactyl.client_features.databases.allow_random', false);
+        config()->set('jexactyl.client_features.databases.allow_random', false);
 
         $this->expectException(NoSuitableDatabaseHostException::class);
 

--- a/tests/Integration/Services/Deployment/FindViableNodesServiceTest.php
+++ b/tests/Integration/Services/Deployment/FindViableNodesServiceTest.php
@@ -41,7 +41,7 @@ class FindViableNodesServiceTest extends IntegrationTestCase
     /**
      * Ensure that errors are not thrown back when passing in expected values.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2529
+     * @see https://github.com/pterodactyl/panel/issues/2529
      */
     public function testNoExceptionIsThrownIfStringifiedIntegersArePassedForLocations()
     {

--- a/tests/Integration/Services/Schedules/ProcessScheduleServiceTest.php
+++ b/tests/Integration/Services/Schedules/ProcessScheduleServiceTest.php
@@ -89,7 +89,7 @@ class ProcessScheduleServiceTest extends IntegrationTestCase
      * Test that even if a schedule's task sequence gets messed up the first task based on
      * the ascending order of tasks is used.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2534
+     * @see https://github.com/pterodactyl/panel/issues/2534
      */
     public function testFirstSequenceTaskIsFound()
     {
@@ -120,7 +120,7 @@ class ProcessScheduleServiceTest extends IntegrationTestCase
      * Tests that a task's processing state is reset correctly if using "dispatchNow" and there is
      * an exception encountered while running it.
      *
-     * @see https://github.com/Jexactyl/panel/issues/2550
+     * @see https://github.com/pterodactyl/panel/issues/2550
      */
     public function testTaskDispatchedNowIsResetProperlyIfErrorIsEncountered()
     {


### PR DESCRIPTION
This PR corrects the captalization of text `Jexactyl` in codebase, that was caused by the commit https://github.com/Jexactyl/Jexactyl/commit/e567d5ccbae7f09fb58e362ab33880dd3248d5d9