### PR TITLE
Fixed issue where discord unlink failed

### DIFF
--- a/app/Http/Controllers/Api/Client/DiscordController.php
+++ b/app/Http/Controllers/Api/Client/DiscordController.php
@@ -31,8 +31,11 @@ class DiscordController extends ClientApiController
 
     public function unlink(): JsonResponse
     {
+        $user = Auth::user();
+        if (!$user) {
+            return new JsonResponse(['error' => 'No authenticated user'], 401);
+        }
         $user->update(['discord_id' => null]);
-
         return new JsonResponse([], JsonResponse::HTTP_NO_CONTENT);
     }
 


### PR DESCRIPTION
Before this fix, when you used the unlink feature it would error due to user not being defined. 
This fix simply defines user, and checks that user is defined.