### PR TITLE
Make Allow Server Deletion functional

### DIFF
--- a/app/Http/ViewComposers/StoreComposer.php
+++ b/app/Http/ViewComposers/StoreComposer.php
@@ -38,6 +38,10 @@ class StoreComposer extends Composer
                 'enabled' => $this->setting('renewal:editing', Composer::TYPE_BOOL),
             ],
 
+            'deletion' => [
+                'enabled' => $this->setting('renewal:deletion', Composer::TYPE_BOOL),
+            ],
+
             'referrals' => [
                 'enabled' => $this->setting('referrals:enabled', Composer::TYPE_BOOL),
                 'reward' => $this->setting('referrals:reward', Composer::TYPE_INT),

--- a/resources/scripts/components/server/settings/SettingsContainer.tsx
+++ b/resources/scripts/components/server/settings/SettingsContainer.tsx
@@ -35,9 +35,7 @@ export default () => {
                             </div>
                         </CopyOnClick>
                     </TitledGreyBox>
-                    {deletion && (
-                        <DeleteServerBox />
-                    )}
+                    {deletion && <DeleteServerBox />}
                     <ChangeBackgroundBox />
                 </div>
                 <div className={'w-full mt-6 md:flex-1 md:mt-0'}>

--- a/resources/scripts/components/server/settings/SettingsContainer.tsx
+++ b/resources/scripts/components/server/settings/SettingsContainer.tsx
@@ -9,11 +9,12 @@ import RenameServerBox from '@/components/server/settings/RenameServerBox';
 import DeleteServerBox from '@/components/server/settings/DeleteServerBox';
 import ReinstallServerBox from '@/components/server/settings/ReinstallServerBox';
 import ChangeBackgroundBox from '@/components/server/settings/ChangeBackgroundBox';
+import { useStoreState } from 'easy-peasy';
 
 export default () => {
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const node = ServerContext.useStoreState((state) => state.server.data!.node);
-
+    const deletion = useStoreState((state) => state.storefront.data!.deletion.enabled);
     return (
         <ServerContentBlock
             title={'Settings'}
@@ -34,7 +35,9 @@ export default () => {
                             </div>
                         </CopyOnClick>
                     </TitledGreyBox>
-                    <DeleteServerBox />
+                    {deletion && (
+                        <DeleteServerBox />
+                    )}
                     <ChangeBackgroundBox />
                 </div>
                 <div className={'w-full mt-6 md:flex-1 md:mt-0'}>

--- a/resources/scripts/state/storefront.ts
+++ b/resources/scripts/state/storefront.ts
@@ -10,6 +10,9 @@ export interface StorefrontSettings {
     editing: {
         enabled: boolean;
     };
+    deletion: {
+        enabled: boolean;
+    };
     referrals: {
         enabled: boolean;
         reward: number;


### PR DESCRIPTION
Before, the "Allow Server Deletion" toggle in the admin area only updated a value in the database, without any functionality to show or hide the delete button based on this setting. Now, if server deletion is disabled in the settings, the delete button will be hidden.
I've tested this and it worked well.