### PR TITLE
security: fix locale controller input validation (CVE-2025-49132)

### DIFF
--- a/app/Http/Controllers/Base/LocaleController.php
+++ b/app/Http/Controllers/Base/LocaleController.php
@@ -2,11 +2,11 @@
 
 namespace Jexactyl\Http\Controllers\Base;
 
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Translation\Translator;
 use Jexactyl\Http\Controllers\Controller;
 use Illuminate\Contracts\Translation\Loader;
+use Jexactyl\Http\Requests\LocaleRequest;
 
 class LocaleController extends Controller
 {
@@ -20,20 +20,11 @@ class LocaleController extends Controller
     /**
      * Returns translation data given a specific locale and namespace.
      */
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(LocaleRequest $request): JsonResponse
     {
-        $locales = explode(' ', $request->input('locale') ?? '');
-        $namespaces = explode(' ', $request->input('namespace') ?? '');
-
-        $response = [];
-        foreach ($locales as $locale) {
-            $response[$locale] = [];
-            foreach ($namespaces as $namespace) {
-                $response[$locale][$namespace] = $this->i18n(
-                    $this->loader->load($locale, str_replace('.', '/', $namespace))
-                );
-            }
-        }
+        $locale = $request->input('locale');
+        $namespace = $request->input('namespace');
+        $response[$locale][$namespace] = $this->i18n($this->loader->load($locale, $namespace));
 
         return new JsonResponse($response, 200, [
             // Cache this in the browser for an hour, and allow the browser to use a stale

--- a/app/Http/Requests/LocaleRequest.php
+++ b/app/Http/Requests/LocaleRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jexactyl\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LocaleRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'locale' => ['required', 'string', 'regex:/^[a-z][a-z]$/'],
+            'namespace' => ['required', 'string', 'regex:/^[a-z]{1,191}$/'],
+        ];
+    }
+}


### PR DESCRIPTION
## Fix CVE-2025-49132 - Critical Security Vulnerability
Adds input validation to LocaleController to fix critical CVSS 10.0 vulnerability.
Prevents exploitation of the locale endpoint with malicious input.