### PR TITLE
fix(schedule): fix issue where schedule was not working properly

### DIFF
--- a/resources/scripts/api/definitions/server/transformers.ts
+++ b/resources/scripts/api/definitions/server/transformers.ts
@@ -156,7 +156,7 @@ export default class Transformers {
             createdAt: new Date(attributes.created_at),
             updatedAt: new Date(attributes.updated_at),
             // @ts-expect-error this is fine
-            tasks: (attributes.relationships?.tasks?.data || []).map((row: any) => this.toServerTask(row.attributes)),
+            tasks: (attributes.relationships?.tasks?.data || []).map((row: any) => this.toTask(row.attributes)),
         };
     };
 }


### PR DESCRIPTION
Previously, schedules did not behave as expected:

- Existing schedules were not displayed correctly.

- When creating a new schedule, it appeared to be created successfully at first, but disappeared after a page refresh.

This PR fixes the issue so that schedules are now properly created and persist as expected, and existing schedules are correctly displayed.