### PR TITLE
Feature/OIDC sso

### DIFF
--- a/app/Http/Controllers/Api/Application/ApplicationApiController.php
+++ b/app/Http/Controllers/Api/Application/ApplicationApiController.php
@@ -60,7 +60,7 @@ abstract class ApplicationApiController extends Controller
      */
     protected function returnNoContent(): Response
     {
-        return $this->returnNoContent();
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 
     /**

--- a/app/Http/Controllers/Api/Application/Auth/ModuleController.php
+++ b/app/Http/Controllers/Api/Application/Auth/ModuleController.php
@@ -27,10 +27,12 @@ class ModuleController extends ApplicationApiController
      */
     public function enable(EnableAuthModuleRequest $request): Response
     {
-        Setting::set('settings::modules:auth:' . $request->all()[0] . ':enabled', true);
+        $module = $request->input('module');
+
+        Setting::set('settings::modules:auth:' . $module . ':enabled', true);
 
         Activity::event('admin:auth:module:enable')
-            ->property('module', $request->all()[0])
+            ->property('module', $module)
             ->description('An authentication module was enabled')
             ->log();
 
@@ -44,10 +46,12 @@ class ModuleController extends ApplicationApiController
      */
     public function disable(DisableAuthModuleRequest $request): Response
     {
-        Setting::set('settings::modules:auth:' . $request->all()[0] . ':enabled', false);
+        $module = $request->input('module');
+
+        Setting::set('settings::modules:auth:' . $module . ':enabled', false);
 
         Activity::event('admin:auth:module:disable')
-            ->property('module', $request->all()[0])
+            ->property('module', $module)
             ->description('An authentication module was disabled')
             ->log();
 

--- a/app/Http/Controllers/Api/Application/Auth/ModuleController.php
+++ b/app/Http/Controllers/Api/Application/Auth/ModuleController.php
@@ -29,6 +29,10 @@ class ModuleController extends ApplicationApiController
     {
         $module = $request->input('module');
 
+        if (!in_array($module, ['discord', 'google', 'oidc', 'jguard', 'onboarding'], true)) {
+            abort(422, 'Invalid module name.');
+        }
+
         Setting::set('settings::modules:auth:' . $module . ':enabled', true);
 
         Activity::event('admin:auth:module:enable')
@@ -47,6 +51,10 @@ class ModuleController extends ApplicationApiController
     public function disable(DisableAuthModuleRequest $request): Response
     {
         $module = $request->input('module');
+
+        if (!in_array($module, ['discord', 'google', 'oidc', 'jguard', 'onboarding'], true)) {
+            abort(422, 'Invalid module name.');
+        }
 
         Setting::set('settings::modules:auth:' . $module . ':enabled', false);
 

--- a/app/Http/Controllers/Api/Client/ClientApiController.php
+++ b/app/Http/Controllers/Api/Client/ClientApiController.php
@@ -10,10 +10,12 @@ abstract class ClientApiController extends ApplicationApiController
     /**
      * Returns only the includes which are valid for the given transformer.
      */
-    protected function getIncludesForTransformer(Transformer $transformer, array $merge = []): array
+    protected function getIncludesForTransformer(string|Transformer $transformer, array $merge = []): array
     {
-        $filtered = array_filter($this->parseIncludes(), function ($datum) use ($transformer) {
-            return in_array($datum, $transformer->getAvailableIncludes());
+        $instance = is_string($transformer) ? app($transformer) : $transformer;
+
+        $filtered = array_filter($this->parseIncludes(), function ($datum) use ($instance) {
+            return in_array($datum, $instance->getAvailableIncludes());
         });
 
         return array_merge($filtered, $merge);

--- a/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
@@ -34,6 +34,6 @@ class ResourceUtilizationController extends ClientApiController
             return $this->repository->setServer($server)->getDetails();
         });
 
-        return $this->transform($stats, StatsTransformer::class);
+        return $this->fractal->item($stats, new StatsTransformer())->toArray();
     }
 }

--- a/app/Http/Controllers/Auth/LoginCheckpointController.php
+++ b/app/Http/Controllers/Auth/LoginCheckpointController.php
@@ -7,6 +7,7 @@ use Everest\Models\User;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use PragmaRX\Google2FA\Google2FA;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -43,6 +44,10 @@ class LoginCheckpointController extends AbstractLoginController
      */
     public function __invoke(LoginCheckpointRequest $request): JsonResponse
     {
+        if (boolval(config('modules.auth.oidc.enabled')) && boolval(config('modules.auth.oidc.disable_local_login'))) {
+            return new JsonResponse(['error' => 'Local login is disabled.'], Response::HTTP_FORBIDDEN);
+        }
+
         if ($this->hasTooManyLoginAttempts($request)) {
             $this->sendLockoutResponse($request);
         }

--- a/app/Http/Controllers/Auth/LoginCheckpointController.php
+++ b/app/Http/Controllers/Auth/LoginCheckpointController.php
@@ -44,10 +44,6 @@ class LoginCheckpointController extends AbstractLoginController
      */
     public function __invoke(LoginCheckpointRequest $request): JsonResponse
     {
-        if (boolval(config('modules.auth.oidc.enabled')) && boolval(config('modules.auth.oidc.disable_local_login'))) {
-            return new JsonResponse(['error' => 'Local login is disabled.'], Response::HTTP_FORBIDDEN);
-        }
-
         if ($this->hasTooManyLoginAttempts($request)) {
             $this->sendLockoutResponse($request);
         }
@@ -55,6 +51,14 @@ class LoginCheckpointController extends AbstractLoginController
         $details = $request->session()->get('auth_confirmation_token');
         if (!$this->hasValidSessionData($details)) {
             $this->sendFailedLoginResponse($request, null, self::TOKEN_EXPIRED_MESSAGE);
+        }
+
+        // The disable_local_login switch blocks 2FA challenges started by the
+        // password flow, but OIDC-initiated checkpoints must still complete —
+        // the user is authenticating via OIDC and asserting their local TOTP.
+        $viaOidc = is_array($details) && ($details['via_oidc'] ?? false) === true;
+        if (!$viaOidc && boolval(config('modules.auth.oidc.enabled')) && boolval(config('modules.auth.oidc.disable_local_login'))) {
+            return new JsonResponse(['error' => 'Local login is disabled.'], Response::HTTP_FORBIDDEN);
         }
 
         if (!hash_equals($request->input('confirmation_token') ?? '', $details['token_value'])) {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -41,6 +41,12 @@ class LoginController extends AbstractLoginController
      */
     public function login(Request $request): JsonResponse
     {
+        if (boolval(config('modules.auth.oidc.enabled')) && boolval(config('modules.auth.oidc.disable_local_login'))) {
+            return new JsonResponse([
+                'error' => 'Local login is disabled. Please use OIDC SSO to sign in.',
+            ], Response::HTTP_FORBIDDEN);
+        }
+
         if ($this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
             $this->sendLockoutResponse($request);

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -285,9 +285,19 @@ class OidcLoginController extends AbstractLoginController
         if (empty($email)) {
             throw new DisplayException('OIDC provider did not return an email address. Ensure the "email" scope is granted.');
         }
-        if ($emailVerified !== true && $emailVerified !== 'true' && $emailVerified !== 1 && $emailVerified !== '1') {
+        $requireVerified = boolval(config('modules.auth.oidc.require_verified_email', true));
+        $isVerified = $emailVerified === true || $emailVerified === 'true' || $emailVerified === 1 || $emailVerified === '1';
+        if ($requireVerified && !$isVerified) {
             Log::warning('[OIDC] rejecting login with unverified email', ['sub' => $claims['sub'] ?? null]);
             throw new DisplayException('OIDC provider returned an unverified email address. The administrator must configure the provider to verify email addresses before accounts can be matched.');
+        }
+        if (!$requireVerified && !$isVerified) {
+            // Logged so admins can audit which accounts came in without a verified email
+            // claim while the safety toggle was off.
+            Log::warning('[OIDC] accepting unverified-email login (toggle disabled)', [
+                'sub' => $claims['sub'] ?? null,
+                'email_verified' => $emailVerified,
+            ]);
         }
 
         // Match the user by the OIDC (iss, sub) pair — the only stable, opaque

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -121,6 +121,22 @@ class OidcLoginController extends AbstractLoginController
      */
     public function authenticate(Request $request): RedirectResponse
     {
+        try {
+            return $this->doAuthenticate($request);
+        } catch (DisplayException $e) {
+            // DisplayException::render() redirects back without logging unless
+            // there is a previous exception, so OIDC validation failures
+            // would otherwise vanish into a silent redirect to /auth/login.
+            Log::warning('[OIDC] authenticate() rejected: ' . $e->getMessage());
+            throw $e;
+        }
+    }
+
+    /**
+     * @throws DisplayException
+     */
+    private function doAuthenticate(Request $request): RedirectResponse
+    {
         Log::debug('[OIDC] authenticate() called', [
             'session_id' => $request->session()->getId(),
             'has_state'  => $request->has('state'),
@@ -207,11 +223,24 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('OIDC provider did not return an id_token.');
         }
 
+        Log::debug('[OIDC] validating id_token', [
+            'token_keys' => array_keys($tokens),
+            'expected_iss' => rtrim((string) config('modules.auth.oidc.issuer_url'), '/'),
+            'expected_aud' => (string) config('modules.auth.oidc.client_id'),
+        ]);
+
         // Fully validate the id_token: signature against the provider's JWKS,
         // and the iss / aud / exp / iat / nonce claims. Without this, an attacker
         // who can substitute the token-endpoint response (or a misconfigured
         // multi-tenant provider) could forge claims and gain access.
         $idTokenClaims = $this->validateIdToken($idToken, $jwksUri, $expectedNonce);
+
+        Log::debug('[OIDC] id_token validated', [
+            'sub'            => $idTokenClaims['sub'] ?? null,
+            'iss'            => $idTokenClaims['iss'] ?? null,
+            'has_email'      => isset($idTokenClaims['email']),
+            'email_verified' => $idTokenClaims['email_verified'] ?? null,
+        ]);
 
         // Optionally enrich claims with the userinfo endpoint. Email and
         // email_verified MUST come from a validated source; we trust both

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -234,9 +234,46 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('OIDC provider returned an unverified email address. The administrator must configure the provider to verify email addresses before accounts can be matched.');
         }
 
-        if (User::where('email', $email)->exists()) {
+        // Match the user by the OIDC (iss, sub) pair — the only stable, opaque
+        // identifier guaranteed by the spec. Fall back to email lookup for
+        // first-time linking of accounts created before sub-based binding, or
+        // for accounts created via the local flow that now sign in via OIDC.
+        $tokenIss = (string) ($claims['iss'] ?? '');
+        $tokenSub = (string) ($claims['sub'] ?? '');
+
+        $user = User::query()
+            ->where('oidc_iss', $tokenIss)
+            ->where('oidc_sub', $tokenSub)
+            ->first();
+
+        if ($user === null) {
             $user = User::where('email', $email)->first();
-        } else {
+
+            if ($user !== null) {
+                // Refuse to silently re-bind an account that is already linked to
+                // a *different* OIDC identity. This protects against admins
+                // switching providers (or two different upstream accounts with
+                // the same verified email) silently inheriting the panel account.
+                if (!empty($user->oidc_sub) && (
+                    $user->oidc_iss !== $tokenIss || $user->oidc_sub !== $tokenSub
+                )) {
+                    Log::warning('[OIDC] refusing to relink account already bound to a different OIDC identity', [
+                        'user_id' => $user->id,
+                    ]);
+                    throw new DisplayException('This account is already linked to a different OIDC identity. Contact an administrator to reconcile.');
+                }
+
+                // JIT-link this previously-unlinked account to the verified
+                // (iss, sub) so subsequent logins match directly even if the
+                // email later changes upstream.
+                $user->forceFill([
+                    'oidc_iss' => $tokenIss,
+                    'oidc_sub' => $tokenSub,
+                ])->save();
+            }
+        }
+
+        if ($user === null) {
             // Derive a username from the OIDC claims. preferred_username is the
             // standard claim; fall back to the local-part of the email.
             $rawUsername = $claims['preferred_username']
@@ -265,6 +302,8 @@ class OidcLoginController extends AbstractLoginController
             $user = $this->creation->handle([
                 'email'    => $email,
                 'username' => $username,
+                'oidc_iss' => $tokenIss,
+                'oidc_sub' => $tokenSub,
             ]);
         }
 

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -58,7 +58,12 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('OIDC issuer URL resolves to a disallowed (private or reserved) address.');
         }
 
-        $response = Http::get($issuer . '/.well-known/openid-configuration');
+        try {
+            $response = Http::timeout(5)->connectTimeout(3)->get($issuer . '/.well-known/openid-configuration');
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            Log::error('[OIDC] discovery fetch failed: ' . $e->getMessage());
+            throw new DisplayException('Could not reach the OIDC provider at ' . $issuer . '. Check that the panel host can resolve and connect to that hostname.');
+        }
 
         if (!$response->successful()) {
             throw new DisplayException('Failed to fetch OIDC discovery document from: ' . $issuer);
@@ -170,13 +175,18 @@ class OidcLoginController extends AbstractLoginController
         }
 
         // Exchange authorization code for tokens.
-        $tokenResponse = Http::asForm()->post($tokenEndpoint, [
-            'grant_type'    => 'authorization_code',
-            'client_id'     => config('modules.auth.oidc.client_id'),
-            'client_secret' => config('modules.auth.oidc.client_secret'),
-            'redirect_uri'  => route('auth.modules.oidc.authenticate'),
-            'code'          => $request->input('code'),
-        ]);
+        try {
+            $tokenResponse = Http::asForm()->timeout(10)->connectTimeout(3)->post($tokenEndpoint, [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => config('modules.auth.oidc.client_id'),
+                'client_secret' => config('modules.auth.oidc.client_secret'),
+                'redirect_uri'  => route('auth.modules.oidc.authenticate'),
+                'code'          => $request->input('code'),
+            ]);
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            Log::error('[OIDC] token endpoint unreachable: ' . $e->getMessage());
+            throw new DisplayException('Could not reach the OIDC token endpoint.');
+        }
 
         if (!$tokenResponse->successful()) {
             Log::error('[OIDC] token exchange failed', ['status' => $tokenResponse->status(), 'body' => substr($tokenResponse->body(), 0, 500)]);
@@ -209,8 +219,13 @@ class OidcLoginController extends AbstractLoginController
         // access_token over TLS to the same provider).
         $claims = $idTokenClaims;
         if (!empty($userinfoEndpoint)) {
-            $userinfo = Http::withToken($accessToken)->get($userinfoEndpoint);
-            if ($userinfo->successful()) {
+            try {
+                $userinfo = Http::withToken($accessToken)->timeout(5)->connectTimeout(3)->get($userinfoEndpoint);
+            } catch (\Illuminate\Http\Client\ConnectionException $e) {
+                Log::warning('[OIDC] userinfo unreachable, continuing with id_token claims: ' . $e->getMessage());
+                $userinfo = null;
+            }
+            if ($userinfo !== null && $userinfo->successful()) {
                 $userinfoClaims = $userinfo->json() ?? [];
                 // Per OIDC Core 5.3.2 the userinfo `sub` MUST match the id_token `sub`.
                 $userinfoSub = $userinfoClaims['sub'] ?? null;
@@ -373,7 +388,12 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('Unsupported OIDC id_token signing algorithm: ' . $alg);
         }
 
-        $jwksResponse = Http::get($jwksUri);
+        try {
+            $jwksResponse = Http::timeout(5)->connectTimeout(3)->get($jwksUri);
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            Log::error('[OIDC] JWKS endpoint unreachable: ' . $e->getMessage());
+            throw new DisplayException('Could not reach the OIDC JWKS endpoint to verify the id_token signature.');
+        }
         if (!$jwksResponse->successful()) {
             throw new DisplayException('Failed to fetch OIDC JWKS.');
         }

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Everest\Http\Controllers\Auth\Modules;
+
+use Everest\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Illuminate\Http\RedirectResponse;
+use Everest\Exceptions\DisplayException;
+use Everest\Http\Controllers\Auth\AbstractLoginController;
+
+class OidcLoginController extends AbstractLoginController
+{
+    /**
+     * OidcLoginController constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Fetch the OIDC provider's discovery document and cache it for the request.
+     *
+     * @throws DisplayException
+     */
+    protected function discover(): array
+    {
+        $issuer = rtrim(config('modules.auth.oidc.issuer_url'), '/');
+
+        if (empty($issuer)) {
+            throw new DisplayException('OIDC issuer URL is not configured.');
+        }
+
+        $response = Http::get($issuer . '/.well-known/openid-configuration');
+
+        if (!$response->successful()) {
+            throw new DisplayException('Failed to fetch OIDC discovery document from: ' . $issuer);
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Build the authorization URL and redirect the user to the OIDC provider.
+     *
+     * @throws DisplayException
+     * @throws \Everest\Exceptions\DisplayException
+     */
+    public function requestToken(Request $request): string
+    {
+        if ($this->hasTooManyLoginAttempts($request)) {
+            $this->fireLockoutEvent($request);
+            $this->sendLockoutResponse($request);
+        }
+
+        $discovery = $this->discover();
+        $authorizationEndpoint = $discovery['authorization_endpoint'] ?? null;
+
+        if (empty($authorizationEndpoint)) {
+            throw new DisplayException('OIDC provider does not expose an authorization_endpoint.');
+        }
+
+        $state = Str::random(40);
+        $request->session()->put('oidc_state', $state);
+
+        $scopes = array_filter(array_merge(
+            ['openid', 'email', 'profile'],
+            explode(' ', config('modules.auth.oidc.scopes', ''))
+        ));
+
+        $query = http_build_query([
+            'client_id'     => config('modules.auth.oidc.client_id'),
+            'redirect_uri'  => route('auth.modules.oidc.authenticate'),
+            'response_type' => 'code',
+            'scope'         => implode(' ', array_unique($scopes)),
+            'state'         => encrypt($state),
+        ]);
+
+        return $authorizationEndpoint . '?' . $query;
+    }
+
+    /**
+     * Handle the OIDC callback, exchange the code for tokens, and log the user in.
+     *
+     * @throws DisplayException
+     */
+    public function authenticate(Request $request): RedirectResponse
+    {
+        // Validate the state parameter to prevent CSRF.
+        $encryptedState = $request->input('state');
+        $expectedState  = $request->session()->pull('oidc_state');
+
+        try {
+            $receivedState = decrypt($encryptedState);
+        } catch (\Exception) {
+            throw new DisplayException('OIDC state parameter could not be decrypted.');
+        }
+
+        if (!$expectedState || !hash_equals($expectedState, $receivedState)) {
+            throw new DisplayException('OIDC state mismatch — possible CSRF attack.');
+        }
+
+        if ($request->has('error')) {
+            throw new DisplayException('OIDC provider returned an error: ' . $request->input('error_description', $request->input('error')));
+        }
+
+        $discovery = $this->discover();
+        $tokenEndpoint    = $discovery['token_endpoint'] ?? null;
+        $userinfoEndpoint = $discovery['userinfo_endpoint'] ?? null;
+
+        if (empty($tokenEndpoint)) {
+            throw new DisplayException('OIDC provider does not expose a token_endpoint.');
+        }
+
+        // Exchange authorization code for tokens.
+        $tokenResponse = Http::asForm()->post($tokenEndpoint, [
+            'grant_type'    => 'authorization_code',
+            'client_id'     => config('modules.auth.oidc.client_id'),
+            'client_secret' => config('modules.auth.oidc.client_secret'),
+            'redirect_uri'  => route('auth.modules.oidc.authenticate'),
+            'code'          => $request->input('code'),
+        ]);
+
+        if (!$tokenResponse->successful()) {
+            throw new DisplayException('OIDC token exchange failed: ' . $tokenResponse->body());
+        }
+
+        $tokens      = $tokenResponse->json();
+        $accessToken = $tokens['access_token'] ?? null;
+
+        if (empty($accessToken)) {
+            throw new DisplayException('OIDC provider did not return an access_token.');
+        }
+
+        // Try to get the user's email. Prefer userinfo endpoint; fall back to parsing the id_token.
+        $email = null;
+
+        if (!empty($userinfoEndpoint)) {
+            $userinfo = Http::withToken($accessToken)->get($userinfoEndpoint);
+
+            if ($userinfo->successful()) {
+                $email = $userinfo->json('email');
+            }
+        }
+
+        // Fall back to the id_token JWT payload (no signature verification needed here —
+        // we already proved we received the code over TLS from the real provider).
+        if (empty($email) && !empty($tokens['id_token'])) {
+            $parts   = explode('.', $tokens['id_token']);
+            $payload = json_decode(base64_decode(strtr($parts[1] ?? '', '-_', '+/')), true);
+            $email   = $payload['email'] ?? null;
+        }
+
+        if (empty($email)) {
+            throw new DisplayException('OIDC provider did not return an email address. Ensure the "email" scope is granted.');
+        }
+
+        if (User::where('email', $email)->exists()) {
+            $user = User::where('email', $email)->first();
+
+            $this->sendLoginResponse($user, $request);
+
+            return redirect('/');
+        }
+
+        $user = $this->createAccount([
+            'email'    => $email,
+            'username' => 'null_user_' . $this->randStr(16),
+        ]);
+
+        $this->sendLoginResponse($user, $request);
+
+        return redirect('/account/setup');
+    }
+
+    /**
+     * Create a random string we can use for a temporary username.
+     */
+    public function randStr(int $length = 10): string
+    {
+        return substr(str_shuffle(str_repeat($x = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', (int) ceil($length / strlen($x)))), 1, $length);
+    }
+}

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -3,6 +3,7 @@
 namespace Everest\Http\Controllers\Auth\Modules;
 
 use Carbon\CarbonImmutable;
+use Everest\Facades\Activity;
 use Everest\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -265,6 +266,26 @@ class OidcLoginController extends AbstractLoginController
                 'email'    => $email,
                 'username' => $username,
             ]);
+        }
+
+        // If the user opted into TOTP locally, honour it: stash a checkpoint
+        // token in the session and hand off to the same 2FA flow the password
+        // path uses. The via_oidc marker lets LoginCheckpointController allow
+        // completion even when disable_local_login is set.
+        if ($user->use_totp) {
+            Activity::event('auth:checkpoint')->withRequestMetadata()->subject($user)->log();
+
+            $token = Str::random(64);
+            $request->session()->put('auth_confirmation_token', [
+                'user_id' => $user->id,
+                'token_value' => $token,
+                'expires_at' => CarbonImmutable::now()->addMinutes(5),
+                'via_oidc' => true,
+            ]);
+
+            Log::info('[OIDC] login pending TOTP checkpoint', ['user_id' => $user->id]);
+
+            return redirect('/auth/login/checkpoint?token=' . urlencode($token));
         }
 
         // Use sendLoginResponse() so it removes 'auth_confirmation_token' from the

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -22,6 +22,17 @@ class OidcLoginController extends AbstractLoginController
     ];
 
     /**
+     * HMAC algorithms (symmetric: the key is the configured client_secret).
+     * Verification is equivalent in security to RS* when the id_token comes
+     * directly from the token endpoint over TLS with confidential-client auth.
+     */
+    private const SUPPORTED_HMAC_ALGS = [
+        'HS256' => 'sha256',
+        'HS384' => 'sha384',
+        'HS512' => 'sha512',
+    ];
+
+    /**
      * Allow up to 5 minutes of clock skew when validating id_token timestamps.
      */
     private const CLOCK_SKEW_SECONDS = 300;
@@ -186,9 +197,10 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('OIDC provider does not expose a token_endpoint.');
         }
 
-        if (empty($jwksUri)) {
-            throw new DisplayException('OIDC provider does not expose a jwks_uri — cannot verify id_token.');
-        }
+        // jwks_uri is only required for asymmetric (RS*) id_token signing —
+        // HMAC-signed (HS*) id_tokens are verified against the client_secret,
+        // not against a JWKS. We defer the missing-jwks_uri error to
+        // validateIdToken() so HS* providers without a JWKS still work.
 
         // Exchange authorization code for tokens.
         try {
@@ -391,12 +403,13 @@ class OidcLoginController extends AbstractLoginController
     }
 
     /**
-     * Verify an OIDC id_token: signature against the provider's JWKS, then the
-     * iss / aud / exp / iat / nonce claims. Returns the decoded payload.
+     * Verify an OIDC id_token: signature (RS* against JWKS, HS* against the
+     * client_secret), then the iss / aud / exp / iat / nonce claims. Returns
+     * the decoded payload.
      *
      * @throws DisplayException
      */
-    private function validateIdToken(string $idToken, string $jwksUri, string $expectedNonce): array
+    private function validateIdToken(string $idToken, ?string $jwksUri, string $expectedNonce): array
     {
         $parts = explode('.', $idToken);
         if (count($parts) !== 3) {
@@ -413,42 +426,55 @@ class OidcLoginController extends AbstractLoginController
         if (empty($alg) || strtolower((string) $alg) === 'none') {
             throw new DisplayException('OIDC id_token must be signed.');
         }
-        if (!array_key_exists($alg, self::SUPPORTED_RSA_ALGS)) {
-            throw new DisplayException('Unsupported OIDC id_token signing algorithm: ' . $alg);
-        }
-
-        try {
-            $jwksResponse = Http::timeout(5)->connectTimeout(3)->get($jwksUri);
-        } catch (\Illuminate\Http\Client\ConnectionException $e) {
-            Log::error('[OIDC] JWKS endpoint unreachable: ' . $e->getMessage());
-            throw new DisplayException('Could not reach the OIDC JWKS endpoint to verify the id_token signature.');
-        }
-        if (!$jwksResponse->successful()) {
-            throw new DisplayException('Failed to fetch OIDC JWKS.');
-        }
-        $jwks = $jwksResponse->json();
-        if (empty($jwks['keys']) || !is_array($jwks['keys'])) {
-            throw new DisplayException('OIDC JWKS contained no keys.');
-        }
-
-        $kid = $header['kid'] ?? null;
-        $jwk = $this->selectJwk($jwks['keys'], $kid);
-        if ($jwk === null) {
-            throw new DisplayException('OIDC id_token signing key not found in JWKS.');
-        }
-
-        $pem = $this->jwkToRsaPem($jwk);
-        $key = openssl_pkey_get_public($pem);
-        if ($key === false) {
-            throw new DisplayException('OIDC id_token public key could not be loaded.');
-        }
 
         $signedData = $headerB64 . '.' . $payloadB64;
         $signature  = $this->base64UrlDecode($signatureB64);
 
-        $result = openssl_verify($signedData, $signature, $key, self::SUPPORTED_RSA_ALGS[$alg]);
-        if ($result !== 1) {
-            throw new DisplayException('OIDC id_token signature verification failed.');
+        if (array_key_exists($alg, self::SUPPORTED_HMAC_ALGS)) {
+            $clientSecret = (string) config('modules.auth.oidc.client_secret');
+            if ($clientSecret === '') {
+                throw new DisplayException('OIDC id_token uses HMAC signing but no client_secret is configured.');
+            }
+            $expected = hash_hmac(self::SUPPORTED_HMAC_ALGS[$alg], $signedData, $clientSecret, true);
+            if (!hash_equals($expected, $signature)) {
+                throw new DisplayException('OIDC id_token signature verification failed.');
+            }
+        } elseif (array_key_exists($alg, self::SUPPORTED_RSA_ALGS)) {
+            if (empty($jwksUri)) {
+                throw new DisplayException('OIDC provider does not expose a jwks_uri — cannot verify id_token.');
+            }
+            try {
+                $jwksResponse = Http::timeout(5)->connectTimeout(3)->get($jwksUri);
+            } catch (\Illuminate\Http\Client\ConnectionException $e) {
+                Log::error('[OIDC] JWKS endpoint unreachable: ' . $e->getMessage());
+                throw new DisplayException('Could not reach the OIDC JWKS endpoint to verify the id_token signature.');
+            }
+            if (!$jwksResponse->successful()) {
+                throw new DisplayException('Failed to fetch OIDC JWKS.');
+            }
+            $jwks = $jwksResponse->json();
+            if (empty($jwks['keys']) || !is_array($jwks['keys'])) {
+                throw new DisplayException('OIDC JWKS contained no keys.');
+            }
+
+            $kid = $header['kid'] ?? null;
+            $jwk = $this->selectJwk($jwks['keys'], $kid);
+            if ($jwk === null) {
+                throw new DisplayException('OIDC id_token signing key not found in JWKS.');
+            }
+
+            $pem = $this->jwkToRsaPem($jwk);
+            $key = openssl_pkey_get_public($pem);
+            if ($key === false) {
+                throw new DisplayException('OIDC id_token public key could not be loaded.');
+            }
+
+            $result = openssl_verify($signedData, $signature, $key, self::SUPPORTED_RSA_ALGS[$alg]);
+            if ($result !== 1) {
+                throw new DisplayException('OIDC id_token signature verification failed.');
+            }
+        } else {
+            throw new DisplayException('Unsupported OIDC id_token signing algorithm: ' . $alg);
         }
 
         $payload = json_decode($this->base64UrlDecode($payloadB64), true);

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -138,21 +138,28 @@ class OidcLoginController extends AbstractLoginController
 
         // Try to get the user's email. Prefer userinfo endpoint; fall back to parsing the id_token.
         $email = null;
+        $claims = [];
 
         if (!empty($userinfoEndpoint)) {
             $userinfo = Http::withToken($accessToken)->get($userinfoEndpoint);
 
             if ($userinfo->successful()) {
-                $email = $userinfo->json('email');
+                $claims = $userinfo->json() ?? [];
+                $email = $claims['email'] ?? null;
             }
         }
 
         // Fall back to the id_token JWT payload (no signature verification needed here —
         // we already proved we received the code over TLS from the real provider).
-        if (empty($email) && !empty($tokens['id_token'])) {
+        if ((empty($email) || empty($claims)) && !empty($tokens['id_token'])) {
             $parts   = explode('.', $tokens['id_token']);
-            $payload = json_decode(base64_decode(strtr($parts[1] ?? '', '-_', '+/')), true);
-            $email   = $payload['email'] ?? null;
+            $payload = json_decode(base64_decode(strtr($parts[1] ?? '', '-_', '+/')), true) ?? [];
+            if (empty($email)) {
+                $email = $payload['email'] ?? null;
+            }
+            if (empty($claims)) {
+                $claims = $payload;
+            }
         }
 
         if (empty($email)) {
@@ -162,11 +169,32 @@ class OidcLoginController extends AbstractLoginController
         if (User::where('email', $email)->exists()) {
             $user = User::where('email', $email)->first();
         } else {
+            // Derive a username from the OIDC claims. preferred_username is the
+            // standard claim; fall back to the local-part of the email.
+            $rawUsername = $claims['preferred_username']
+                ?? $claims['nickname']
+                ?? explode('@', $email)[0]
+                ?? null;
+
+            // Sanitise: lowercase, strip disallowed chars, trim non-alphanumeric
+            // edges to satisfy the Username validation rule (/^[a-z0-9]([\w\.-]+)[a-z0-9]$/).
+            $username = strtolower((string) $rawUsername);
+            $username = preg_replace('/[^a-z0-9_.\-]/', '_', $username);
+            $username = trim($username, '_.-');
+
+            // Must be at least 3 chars and unique.
+            if (strlen($username) < 3) {
+                $username = 'sso_' . $username;
+            }
+            if (User::where('username', $username)->exists()) {
+                $username = $username . '_' . $this->randStr(6);
+            }
+
             // Bypass the public registration toggle — OIDC account creation is
             // always admin-controlled via the module being enabled.
             $user = $this->creation->handle([
                 'email'    => $email,
-                'username' => 'null_user_' . $this->randStr(16),
+                'username' => $username,
             ]);
         }
 
@@ -179,9 +207,7 @@ class OidcLoginController extends AbstractLoginController
         $this->auth->guard()->login($user, true);
         Event::dispatch(new DirectLogin($user, true));
 
-        $isNewUser = str_starts_with($user->username, 'null_user_');
-
-        return redirect($isNewUser ? '/account/setup' : '/');
+        return redirect('/');
     }
 
     /**

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -35,6 +35,17 @@ class OidcLoginController extends AbstractLoginController
             throw new DisplayException('OIDC issuer URL is not configured.');
         }
 
+        $parsed = parse_url($issuer);
+        if (($parsed['scheme'] ?? '') !== 'https') {
+            throw new DisplayException('OIDC issuer URL must use the https:// scheme.');
+        }
+
+        $host = $parsed['host'] ?? '';
+        $resolved = gethostbyname($host);
+        if (filter_var($resolved, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            throw new DisplayException('OIDC issuer URL resolves to a disallowed (private or reserved) address.');
+        }
+
         $response = Http::get($issuer . '/.well-known/openid-configuration');
 
         if (!$response->successful()) {

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -38,6 +38,17 @@ class OidcLoginController extends AbstractLoginController
     private const CLOCK_SKEW_SECONDS = 300;
 
     /**
+     * Outbound HTTP client preconfigured for OIDC: short timeouts and the
+     * admin-controlled TLS verification toggle applied uniformly.
+     */
+    private function http(): \Illuminate\Http\Client\PendingRequest
+    {
+        $verify = boolval(config('modules.auth.oidc.verify_ssl', true));
+
+        return Http::timeout(5)->connectTimeout(3)->withOptions(['verify' => $verify]);
+    }
+
+    /**
      * OidcLoginController constructor.
      */
     public function __construct()
@@ -70,7 +81,7 @@ class OidcLoginController extends AbstractLoginController
         }
 
         try {
-            $response = Http::timeout(5)->connectTimeout(3)->get($issuer . '/.well-known/openid-configuration');
+            $response = $this->http()->get($issuer . '/.well-known/openid-configuration');
         } catch (\Illuminate\Http\Client\ConnectionException $e) {
             Log::error('[OIDC] discovery fetch failed: ' . $e->getMessage());
             throw new DisplayException('Could not reach the OIDC provider at ' . $issuer . '. Check that the panel host can resolve and connect to that hostname.');
@@ -204,7 +215,7 @@ class OidcLoginController extends AbstractLoginController
 
         // Exchange authorization code for tokens.
         try {
-            $tokenResponse = Http::asForm()->timeout(10)->connectTimeout(3)->post($tokenEndpoint, [
+            $tokenResponse = $this->http()->timeout(10)->asForm()->post($tokenEndpoint, [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => config('modules.auth.oidc.client_id'),
                 'client_secret' => config('modules.auth.oidc.client_secret'),
@@ -261,7 +272,7 @@ class OidcLoginController extends AbstractLoginController
         $claims = $idTokenClaims;
         if (!empty($userinfoEndpoint)) {
             try {
-                $userinfo = Http::withToken($accessToken)->timeout(5)->connectTimeout(3)->get($userinfoEndpoint);
+                $userinfo = $this->http()->withToken($accessToken)->get($userinfoEndpoint);
             } catch (\Illuminate\Http\Client\ConnectionException $e) {
                 Log::warning('[OIDC] userinfo unreachable, continuing with id_token claims: ' . $e->getMessage());
                 $userinfo = null;
@@ -454,7 +465,7 @@ class OidcLoginController extends AbstractLoginController
                 throw new DisplayException('OIDC provider does not expose a jwks_uri — cannot verify id_token.');
             }
             try {
-                $jwksResponse = Http::timeout(5)->connectTimeout(3)->get($jwksUri);
+                $jwksResponse = $this->http()->get($jwksUri);
             } catch (\Illuminate\Http\Client\ConnectionException $e) {
                 Log::error('[OIDC] JWKS endpoint unreachable: ' . $e->getMessage());
                 throw new DisplayException('Could not reach the OIDC JWKS endpoint to verify the id_token signature.');

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -5,10 +5,9 @@ namespace Everest\Http\Controllers\Auth\Modules;
 use Everest\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Http\RedirectResponse;
-use Everest\Events\Auth\DirectLogin;
 use Everest\Exceptions\DisplayException;
 use Everest\Http\Controllers\Auth\AbstractLoginController;
 
@@ -101,29 +100,46 @@ class OidcLoginController extends AbstractLoginController
      */
     public function authenticate(Request $request): RedirectResponse
     {
+        Log::debug('[OIDC] authenticate() called', [
+            'session_id' => $request->session()->getId(),
+            'has_state'  => $request->has('state'),
+            'has_code'   => $request->has('code'),
+            'has_error'  => $request->has('error'),
+        ]);
+
         // Validate the state parameter to prevent CSRF.
         $encryptedState = $request->input('state');
         $expectedState  = $request->session()->pull('oidc_state');
 
         try {
             $receivedState = decrypt($encryptedState);
-        } catch (\Exception) {
+        } catch (\Throwable $e) {
+            Log::error('[OIDC] state decrypt failed: ' . $e->getMessage());
             throw new DisplayException('OIDC state parameter could not be decrypted.');
         }
 
         if (!$expectedState || !hash_equals($expectedState, $receivedState)) {
+            Log::warning('[OIDC] state mismatch — possible CSRF');
             throw new DisplayException('OIDC state mismatch — possible CSRF attack.');
         }
 
         if ($request->has('error')) {
+            Log::error('[OIDC] provider returned error: ' . $request->input('error_description', $request->input('error')));
             throw new DisplayException('OIDC provider returned an error: ' . $request->input('error_description', $request->input('error')));
         }
 
-        $discovery = $this->discover();
+        try {
+            $discovery = $this->discover();
+        } catch (\Throwable $e) {
+            Log::error('[OIDC] discovery failed: ' . get_class($e) . ': ' . $e->getMessage());
+            throw $e;
+        }
+
         $tokenEndpoint    = $discovery['token_endpoint'] ?? null;
         $userinfoEndpoint = $discovery['userinfo_endpoint'] ?? null;
 
         if (empty($tokenEndpoint)) {
+            Log::error('[OIDC] provider discovery document missing token_endpoint');
             throw new DisplayException('OIDC provider does not expose a token_endpoint.');
         }
 
@@ -137,8 +153,11 @@ class OidcLoginController extends AbstractLoginController
         ]);
 
         if (!$tokenResponse->successful()) {
+            Log::error('[OIDC] token exchange failed', ['status' => $tokenResponse->status(), 'body' => substr($tokenResponse->body(), 0, 500)]);
             throw new DisplayException('OIDC token exchange failed: ' . $tokenResponse->body());
         }
+
+        Log::debug('[OIDC] token exchange OK', ['status' => $tokenResponse->status()]);
 
         $tokens      = $tokenResponse->json();
         $accessToken = $tokens['access_token'] ?? null;
@@ -202,21 +221,30 @@ class OidcLoginController extends AbstractLoginController
             }
 
             // Bypass the public registration toggle — OIDC account creation is
-            // always admin-controlled via the module being enabled.
+            // always admin-controlled via the module being enabled. We create the
+            // User model directly to avoid createAccount()'s registration-enabled
+            // guard, which would throw DisplayException if self-registration is off.
             $user = $this->creation->handle([
                 'email'    => $email,
                 'username' => $username,
             ]);
         }
 
-        // Regenerate the session and log the user in using the standard web guard.
-        // We do NOT use sendLoginResponse() here — that returns a JsonResponse for
-        // the XHR login flow. For the OIDC web redirect flow we need a proper
-        // server-side session so the Set-Cookie header is included in the redirect.
-        $request->session()->regenerate();
-        $this->clearLoginAttempts($request);
-        $this->auth->guard()->login($user, true);
-        Event::dispatch(new DirectLogin($user, true));
+        // Use sendLoginResponse() so it removes 'auth_confirmation_token' from the
+        // session before regenerating. Skipping that step causes AuthenticateSession
+        // middleware to treat the session as stale on the next request and
+        // immediately log the user back out — they'd be redirected straight back to
+        // the login page. Discard its JsonResponse and return our own redirect.
+        Log::debug('[OIDC] logging in user', ['user_id' => $user->id, 'email' => $user->email]);
+
+        try {
+            $this->sendLoginResponse($user, $request);
+        } catch (\Throwable $e) {
+            Log::error('[OIDC] sendLoginResponse threw: ' . $e->getMessage(), ['trace' => $e->getTraceAsString()]);
+            throw $e;
+        }
+
+        Log::info('[OIDC] login successful', ['user_id' => $user->id, 'email' => $user->email]);
 
         return redirect('/');
     }

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -5,8 +5,10 @@ namespace Everest\Http\Controllers\Auth\Modules;
 use Everest\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Illuminate\Http\RedirectResponse;
+use Everest\Events\Auth\DirectLogin;
 use Everest\Exceptions\DisplayException;
 use Everest\Http\Controllers\Auth\AbstractLoginController;
 
@@ -159,20 +161,27 @@ class OidcLoginController extends AbstractLoginController
 
         if (User::where('email', $email)->exists()) {
             $user = User::where('email', $email)->first();
-
-            $this->sendLoginResponse($user, $request);
-
-            return redirect('/');
+        } else {
+            // Bypass the public registration toggle — OIDC account creation is
+            // always admin-controlled via the module being enabled.
+            $user = $this->creation->handle([
+                'email'    => $email,
+                'username' => 'null_user_' . $this->randStr(16),
+            ]);
         }
 
-        $user = $this->createAccount([
-            'email'    => $email,
-            'username' => 'null_user_' . $this->randStr(16),
-        ]);
+        // Regenerate the session and log the user in using the standard web guard.
+        // We do NOT use sendLoginResponse() here — that returns a JsonResponse for
+        // the XHR login flow. For the OIDC web redirect flow we need a proper
+        // server-side session so the Set-Cookie header is included in the redirect.
+        $request->session()->regenerate();
+        $this->clearLoginAttempts($request);
+        $this->auth->guard()->login($user, true);
+        Event::dispatch(new DirectLogin($user, true));
 
-        $this->sendLoginResponse($user, $request);
+        $isNewUser = str_starts_with($user->username, 'null_user_');
 
-        return redirect('/account/setup');
+        return redirect($isNewUser ? '/account/setup' : '/');
     }
 
     /**

--- a/app/Http/Controllers/Auth/Modules/OidcLoginController.php
+++ b/app/Http/Controllers/Auth/Modules/OidcLoginController.php
@@ -2,6 +2,7 @@
 
 namespace Everest\Http\Controllers\Auth\Modules;
 
+use Carbon\CarbonImmutable;
 use Everest\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -13,6 +14,17 @@ use Everest\Http\Controllers\Auth\AbstractLoginController;
 
 class OidcLoginController extends AbstractLoginController
 {
+    private const SUPPORTED_RSA_ALGS = [
+        'RS256' => OPENSSL_ALGO_SHA256,
+        'RS384' => OPENSSL_ALGO_SHA384,
+        'RS512' => OPENSSL_ALGO_SHA512,
+    ];
+
+    /**
+     * Allow up to 5 minutes of clock skew when validating id_token timestamps.
+     */
+    private const CLOCK_SKEW_SECONDS = 300;
+
     /**
      * OidcLoginController constructor.
      */
@@ -75,7 +87,9 @@ class OidcLoginController extends AbstractLoginController
         }
 
         $state = Str::random(40);
+        $nonce = Str::random(40);
         $request->session()->put('oidc_state', $state);
+        $request->session()->put('oidc_nonce', $nonce);
 
         $scopes = array_filter(array_merge(
             ['openid', 'email', 'profile'],
@@ -88,6 +102,7 @@ class OidcLoginController extends AbstractLoginController
             'response_type' => 'code',
             'scope'         => implode(' ', array_unique($scopes)),
             'state'         => encrypt($state),
+            'nonce'         => $nonce,
         ]);
 
         return $authorizationEndpoint . '?' . $query;
@@ -110,6 +125,7 @@ class OidcLoginController extends AbstractLoginController
         // Validate the state parameter to prevent CSRF.
         $encryptedState = $request->input('state');
         $expectedState  = $request->session()->pull('oidc_state');
+        $expectedNonce  = $request->session()->pull('oidc_nonce');
 
         try {
             $receivedState = decrypt($encryptedState);
@@ -121,6 +137,10 @@ class OidcLoginController extends AbstractLoginController
         if (!$expectedState || !hash_equals($expectedState, $receivedState)) {
             Log::warning('[OIDC] state mismatch — possible CSRF');
             throw new DisplayException('OIDC state mismatch — possible CSRF attack.');
+        }
+
+        if (empty($expectedNonce)) {
+            throw new DisplayException('OIDC nonce missing from session — restart the login flow.');
         }
 
         if ($request->has('error')) {
@@ -137,10 +157,15 @@ class OidcLoginController extends AbstractLoginController
 
         $tokenEndpoint    = $discovery['token_endpoint'] ?? null;
         $userinfoEndpoint = $discovery['userinfo_endpoint'] ?? null;
+        $jwksUri          = $discovery['jwks_uri'] ?? null;
 
         if (empty($tokenEndpoint)) {
             Log::error('[OIDC] provider discovery document missing token_endpoint');
             throw new DisplayException('OIDC provider does not expose a token_endpoint.');
+        }
+
+        if (empty($jwksUri)) {
+            throw new DisplayException('OIDC provider does not expose a jwks_uri — cannot verify id_token.');
         }
 
         // Exchange authorization code for tokens.
@@ -154,46 +179,58 @@ class OidcLoginController extends AbstractLoginController
 
         if (!$tokenResponse->successful()) {
             Log::error('[OIDC] token exchange failed', ['status' => $tokenResponse->status(), 'body' => substr($tokenResponse->body(), 0, 500)]);
-            throw new DisplayException('OIDC token exchange failed: ' . $tokenResponse->body());
+            throw new DisplayException('OIDC token exchange failed.');
         }
 
         Log::debug('[OIDC] token exchange OK', ['status' => $tokenResponse->status()]);
 
         $tokens      = $tokenResponse->json();
         $accessToken = $tokens['access_token'] ?? null;
+        $idToken     = $tokens['id_token'] ?? null;
 
         if (empty($accessToken)) {
             throw new DisplayException('OIDC provider did not return an access_token.');
         }
 
-        // Try to get the user's email. Prefer userinfo endpoint; fall back to parsing the id_token.
-        $email = null;
-        $claims = [];
+        if (empty($idToken)) {
+            throw new DisplayException('OIDC provider did not return an id_token.');
+        }
 
+        // Fully validate the id_token: signature against the provider's JWKS,
+        // and the iss / aud / exp / iat / nonce claims. Without this, an attacker
+        // who can substitute the token-endpoint response (or a misconfigured
+        // multi-tenant provider) could forge claims and gain access.
+        $idTokenClaims = $this->validateIdToken($idToken, $jwksUri, $expectedNonce);
+
+        // Optionally enrich claims with the userinfo endpoint. Email and
+        // email_verified MUST come from a validated source; we trust both
+        // the verified id_token and userinfo (which is fetched with the
+        // access_token over TLS to the same provider).
+        $claims = $idTokenClaims;
         if (!empty($userinfoEndpoint)) {
             $userinfo = Http::withToken($accessToken)->get($userinfoEndpoint);
-
             if ($userinfo->successful()) {
-                $claims = $userinfo->json() ?? [];
-                $email = $claims['email'] ?? null;
+                $userinfoClaims = $userinfo->json() ?? [];
+                // Per OIDC Core 5.3.2 the userinfo `sub` MUST match the id_token `sub`.
+                $userinfoSub = $userinfoClaims['sub'] ?? null;
+                if (!empty($userinfoSub) && isset($idTokenClaims['sub']) && !hash_equals((string) $idTokenClaims['sub'], (string) $userinfoSub)) {
+                    throw new DisplayException('OIDC userinfo subject does not match id_token subject.');
+                }
+                $claims = array_merge($claims, $userinfoClaims);
             }
         }
 
-        // Fall back to the id_token JWT payload (no signature verification needed here —
-        // we already proved we received the code over TLS from the real provider).
-        if ((empty($email) || empty($claims)) && !empty($tokens['id_token'])) {
-            $parts   = explode('.', $tokens['id_token']);
-            $payload = json_decode(base64_decode(strtr($parts[1] ?? '', '-_', '+/')), true) ?? [];
-            if (empty($email)) {
-                $email = $payload['email'] ?? null;
-            }
-            if (empty($claims)) {
-                $claims = $payload;
-            }
-        }
-
+        // Require a verified email. If the provider does not assert
+        // email_verified === true, the email claim is untrustworthy and MUST
+        // NOT be used for account matching (see OpenID Connect Core 1.0 §5.7).
+        $email = $claims['email'] ?? null;
+        $emailVerified = $claims['email_verified'] ?? null;
         if (empty($email)) {
             throw new DisplayException('OIDC provider did not return an email address. Ensure the "email" scope is granted.');
+        }
+        if ($emailVerified !== true && $emailVerified !== 'true' && $emailVerified !== 1 && $emailVerified !== '1') {
+            Log::warning('[OIDC] rejecting login with unverified email', ['sub' => $claims['sub'] ?? null]);
+            throw new DisplayException('OIDC provider returned an unverified email address. The administrator must configure the provider to verify email addresses before accounts can be matched.');
         }
 
         if (User::where('email', $email)->exists()) {
@@ -235,7 +272,7 @@ class OidcLoginController extends AbstractLoginController
         // middleware to treat the session as stale on the next request and
         // immediately log the user back out — they'd be redirected straight back to
         // the login page. Discard its JsonResponse and return our own redirect.
-        Log::debug('[OIDC] logging in user', ['user_id' => $user->id, 'email' => $user->email]);
+        Log::debug('[OIDC] logging in user', ['user_id' => $user->id]);
 
         try {
             $this->sendLoginResponse($user, $request);
@@ -244,9 +281,218 @@ class OidcLoginController extends AbstractLoginController
             throw $e;
         }
 
-        Log::info('[OIDC] login successful', ['user_id' => $user->id, 'email' => $user->email]);
+        Log::info('[OIDC] login successful', ['user_id' => $user->id]);
 
         return redirect('/');
+    }
+
+    /**
+     * Verify an OIDC id_token: signature against the provider's JWKS, then the
+     * iss / aud / exp / iat / nonce claims. Returns the decoded payload.
+     *
+     * @throws DisplayException
+     */
+    private function validateIdToken(string $idToken, string $jwksUri, string $expectedNonce): array
+    {
+        $parts = explode('.', $idToken);
+        if (count($parts) !== 3) {
+            throw new DisplayException('OIDC id_token is malformed.');
+        }
+        [$headerB64, $payloadB64, $signatureB64] = $parts;
+
+        $header = json_decode($this->base64UrlDecode($headerB64), true);
+        if (!is_array($header)) {
+            throw new DisplayException('OIDC id_token header could not be parsed.');
+        }
+
+        $alg = $header['alg'] ?? null;
+        if (empty($alg) || strtolower((string) $alg) === 'none') {
+            throw new DisplayException('OIDC id_token must be signed.');
+        }
+        if (!array_key_exists($alg, self::SUPPORTED_RSA_ALGS)) {
+            throw new DisplayException('Unsupported OIDC id_token signing algorithm: ' . $alg);
+        }
+
+        $jwksResponse = Http::get($jwksUri);
+        if (!$jwksResponse->successful()) {
+            throw new DisplayException('Failed to fetch OIDC JWKS.');
+        }
+        $jwks = $jwksResponse->json();
+        if (empty($jwks['keys']) || !is_array($jwks['keys'])) {
+            throw new DisplayException('OIDC JWKS contained no keys.');
+        }
+
+        $kid = $header['kid'] ?? null;
+        $jwk = $this->selectJwk($jwks['keys'], $kid);
+        if ($jwk === null) {
+            throw new DisplayException('OIDC id_token signing key not found in JWKS.');
+        }
+
+        $pem = $this->jwkToRsaPem($jwk);
+        $key = openssl_pkey_get_public($pem);
+        if ($key === false) {
+            throw new DisplayException('OIDC id_token public key could not be loaded.');
+        }
+
+        $signedData = $headerB64 . '.' . $payloadB64;
+        $signature  = $this->base64UrlDecode($signatureB64);
+
+        $result = openssl_verify($signedData, $signature, $key, self::SUPPORTED_RSA_ALGS[$alg]);
+        if ($result !== 1) {
+            throw new DisplayException('OIDC id_token signature verification failed.');
+        }
+
+        $payload = json_decode($this->base64UrlDecode($payloadB64), true);
+        if (!is_array($payload)) {
+            throw new DisplayException('OIDC id_token payload could not be parsed.');
+        }
+
+        $now = CarbonImmutable::now()->getTimestamp();
+
+        $exp = $payload['exp'] ?? null;
+        if (!is_numeric($exp) || ((int) $exp + self::CLOCK_SKEW_SECONDS) < $now) {
+            throw new DisplayException('OIDC id_token is expired or missing an exp claim.');
+        }
+
+        $iat = $payload['iat'] ?? null;
+        if (!is_numeric($iat) || ((int) $iat - self::CLOCK_SKEW_SECONDS) > $now) {
+            throw new DisplayException('OIDC id_token has an invalid iat claim.');
+        }
+
+        $nbf = $payload['nbf'] ?? null;
+        if ($nbf !== null && (!is_numeric($nbf) || ((int) $nbf - self::CLOCK_SKEW_SECONDS) > $now)) {
+            throw new DisplayException('OIDC id_token is not yet valid (nbf).');
+        }
+
+        $expectedIss = rtrim((string) config('modules.auth.oidc.issuer_url'), '/');
+        $tokenIss    = rtrim((string) ($payload['iss'] ?? ''), '/');
+        if (empty($tokenIss) || !hash_equals($expectedIss, $tokenIss)) {
+            throw new DisplayException('OIDC id_token issuer does not match the configured issuer.');
+        }
+
+        $expectedAud = (string) config('modules.auth.oidc.client_id');
+        $tokenAud    = $payload['aud'] ?? null;
+        $audMatches  = is_array($tokenAud)
+            ? in_array($expectedAud, array_map('strval', $tokenAud), true)
+            : (string) $tokenAud === $expectedAud;
+        if (!$audMatches) {
+            throw new DisplayException('OIDC id_token audience does not match the configured client_id.');
+        }
+
+        // If azp is present, it MUST equal our client_id (OIDC Core 1.0 §3.1.3.7 step 5).
+        if (isset($payload['azp']) && (string) $payload['azp'] !== $expectedAud) {
+            throw new DisplayException('OIDC id_token azp claim does not match the configured client_id.');
+        }
+
+        $tokenNonce = $payload['nonce'] ?? null;
+        if (empty($tokenNonce) || !hash_equals($expectedNonce, (string) $tokenNonce)) {
+            throw new DisplayException('OIDC id_token nonce mismatch — possible replay.');
+        }
+
+        if (empty($payload['sub'])) {
+            throw new DisplayException('OIDC id_token is missing the sub claim.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Pick the JWK to verify with. Prefers a key whose kid matches the JWT header;
+     * otherwise falls back to the single key in the set when no kid is supplied.
+     */
+    private function selectJwk(array $keys, ?string $kid): ?array
+    {
+        if ($kid !== null) {
+            foreach ($keys as $key) {
+                if (!is_array($key)) {
+                    continue;
+                }
+                if (($key['kty'] ?? '') !== 'RSA') {
+                    continue;
+                }
+                if (($key['use'] ?? 'sig') !== 'sig') {
+                    continue;
+                }
+                if (($key['kid'] ?? null) === $kid) {
+                    return $key;
+                }
+            }
+
+            return null;
+        }
+
+        $candidates = array_values(array_filter($keys, function ($key) {
+            return is_array($key) && ($key['kty'] ?? '') === 'RSA' && ($key['use'] ?? 'sig') === 'sig';
+        }));
+
+        return count($candidates) === 1 ? $candidates[0] : null;
+    }
+
+    /**
+     * Convert a JWK RSA public key into a PEM-encoded SubjectPublicKeyInfo so
+     * that openssl_verify() can use it.
+     */
+    private function jwkToRsaPem(array $jwk): string
+    {
+        if (($jwk['kty'] ?? '') !== 'RSA' || empty($jwk['n']) || empty($jwk['e'])) {
+            throw new DisplayException('Only RSA OIDC signing keys are supported.');
+        }
+
+        $n = $this->base64UrlDecode($jwk['n']);
+        $e = $this->base64UrlDecode($jwk['e']);
+        if ($n === '' || $e === '') {
+            throw new DisplayException('OIDC JWK has empty modulus or exponent.');
+        }
+
+        $rsaPublicKey = $this->asn1Sequence(
+            $this->asn1Integer($n) . $this->asn1Integer($e)
+        );
+
+        // SubjectPublicKeyInfo: AlgorithmIdentifier(rsaEncryption) || BIT STRING(RSAPublicKey).
+        $algorithm = $this->asn1Sequence(
+            "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01" // OID 1.2.840.113549.1.1.1
+            . "\x05\x00"                                    // NULL parameters
+        );
+        $bitString = "\x03" . $this->asn1Length(strlen($rsaPublicKey) + 1) . "\x00" . $rsaPublicKey;
+        $spki      = $this->asn1Sequence($algorithm . $bitString);
+
+        return "-----BEGIN PUBLIC KEY-----\n"
+            . chunk_split(base64_encode($spki), 64, "\n")
+            . "-----END PUBLIC KEY-----\n";
+    }
+
+    private function asn1Sequence(string $contents): string
+    {
+        return "\x30" . $this->asn1Length(strlen($contents)) . $contents;
+    }
+
+    private function asn1Integer(string $contents): string
+    {
+        if ((ord($contents[0]) & 0x80) !== 0) {
+            $contents = "\x00" . $contents;
+        }
+
+        return "\x02" . $this->asn1Length(strlen($contents)) . $contents;
+    }
+
+    private function asn1Length(int $length): string
+    {
+        if ($length < 0x80) {
+            return chr($length);
+        }
+        $temp = ltrim(pack('N', $length), "\x00");
+
+        return chr(strlen($temp) | 0x80) . $temp;
+    }
+
+    private function base64UrlDecode(string $data): string
+    {
+        $padding = strlen($data) % 4;
+        if ($padding > 0) {
+            $data .= str_repeat('=', 4 - $padding);
+        }
+
+        return (string) base64_decode(strtr($data, '-_', '+/'), true);
     }
 
     /**

--- a/app/Http/ViewComposers/EverestComposer.php
+++ b/app/Http/ViewComposers/EverestComposer.php
@@ -38,6 +38,7 @@ class EverestComposer
                         'clientSecret' => !empty(config('modules.auth.oidc.client_secret')),
                         'displayName' => config('modules.auth.oidc.display_name', 'SSO'),
                         'disableLocalLogin' => boolval(config('modules.auth.oidc.disable_local_login', false)),
+                        'requireVerifiedEmail' => boolval(config('modules.auth.oidc.require_verified_email', true)),
                         'callbackUrl' => rtrim(config('app.url'), '/') . '/auth/modules/oidc/authenticate',
                     ],
                     'onboarding' => [

--- a/app/Http/ViewComposers/EverestComposer.php
+++ b/app/Http/ViewComposers/EverestComposer.php
@@ -39,6 +39,7 @@ class EverestComposer
                         'displayName' => config('modules.auth.oidc.display_name', 'SSO'),
                         'disableLocalLogin' => boolval(config('modules.auth.oidc.disable_local_login', false)),
                         'requireVerifiedEmail' => boolval(config('modules.auth.oidc.require_verified_email', true)),
+                        'verifySsl' => boolval(config('modules.auth.oidc.verify_ssl', true)),
                         'callbackUrl' => rtrim(config('app.url'), '/') . '/auth/modules/oidc/authenticate',
                     ],
                     'onboarding' => [

--- a/app/Http/ViewComposers/EverestComposer.php
+++ b/app/Http/ViewComposers/EverestComposer.php
@@ -37,6 +37,7 @@ class EverestComposer
                         'clientId' => !empty(config('modules.auth.oidc.client_id')),
                         'clientSecret' => !empty(config('modules.auth.oidc.client_secret')),
                         'displayName' => config('modules.auth.oidc.display_name', 'SSO'),
+                        'disableLocalLogin' => boolval(config('modules.auth.oidc.disable_local_login', false)),
                         'callbackUrl' => rtrim(config('app.url'), '/') . '/auth/modules/oidc/authenticate',
                     ],
                     'onboarding' => [

--- a/app/Http/ViewComposers/EverestComposer.php
+++ b/app/Http/ViewComposers/EverestComposer.php
@@ -31,6 +31,13 @@ class EverestComposer
                         'clientId' => !empty(config('modules.auth.google.client_id', false)),
                         'clientSecret' => !empty(config('modules.auth.google.client_secret')),
                     ],
+                    'oidc' => [
+                        'enabled' => boolval(config('modules.auth.oidc.enabled', false)),
+                        'issuerUrl' => !empty(config('modules.auth.oidc.issuer_url')),
+                        'clientId' => !empty(config('modules.auth.oidc.client_id')),
+                        'clientSecret' => !empty(config('modules.auth.oidc.client_secret')),
+                        'displayName' => config('modules.auth.oidc.display_name', 'SSO'),
+                    ],
                     'onboarding' => [
                         'enabled' => boolval(config('modules.auth.onboarding.enabled', false)),
                         'content' => config('modules.auth.onboarding.content', ''),

--- a/app/Http/ViewComposers/EverestComposer.php
+++ b/app/Http/ViewComposers/EverestComposer.php
@@ -37,6 +37,7 @@ class EverestComposer
                         'clientId' => !empty(config('modules.auth.oidc.client_id')),
                         'clientSecret' => !empty(config('modules.auth.oidc.client_secret')),
                         'displayName' => config('modules.auth.oidc.display_name', 'SSO'),
+                        'callbackUrl' => rtrim(config('app.url'), '/') . '/auth/modules/oidc/authenticate',
                     ],
                     'onboarding' => [
                         'enabled' => boolval(config('modules.auth.onboarding.enabled', false)),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -121,6 +121,8 @@ class User extends Model implements
      */
     protected $fillable = [
         'external_id',
+        'oidc_iss',
+        'oidc_sub',
         'username',
         'email',
         'password',
@@ -169,6 +171,8 @@ class User extends Model implements
         'uuid' => 'required|string|size:36|unique:users,uuid',
         'email' => 'required|email|between:1,191|unique:users,email',
         'external_id' => 'sometimes|nullable|string|max:191|unique:users,external_id',
+        'oidc_iss' => 'sometimes|nullable|string|max:191',
+        'oidc_sub' => 'sometimes|nullable|string|max:191',
         'username' => 'required|between:1,191|unique:users,username',
         'password' => 'sometimes|nullable|string',
         'root_admin' => 'boolean',

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -46,6 +46,13 @@ class SettingsServiceProvider extends ServiceProvider
         'modules:auth:jguard:enabled',
         'modules:auth:jguard:delay',
 
+        'modules:auth:oidc:enabled',
+        'modules:auth:oidc:issuer_url',
+        'modules:auth:oidc:client_id',
+        'modules:auth:oidc:client_secret',
+        'modules:auth:oidc:display_name',
+        'modules:auth:oidc:scopes',
+
         // Billing module settings
         'modules:billing:enabled',
         'modules:billing:keys:secret',

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -54,6 +54,7 @@ class SettingsServiceProvider extends ServiceProvider
         'modules:auth:oidc:scopes',
         'modules:auth:oidc:disable_local_login',
         'modules:auth:oidc:require_verified_email',
+        'modules:auth:oidc:verify_ssl',
 
         // Billing module settings
         'modules:billing:enabled',

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -53,6 +53,7 @@ class SettingsServiceProvider extends ServiceProvider
         'modules:auth:oidc:display_name',
         'modules:auth:oidc:scopes',
         'modules:auth:oidc:disable_local_login',
+        'modules:auth:oidc:require_verified_email',
 
         // Billing module settings
         'modules:billing:enabled',

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -52,6 +52,7 @@ class SettingsServiceProvider extends ServiceProvider
         'modules:auth:oidc:client_secret',
         'modules:auth:oidc:display_name',
         'modules:auth:oidc:scopes',
+        'modules:auth:oidc:disable_local_login',
 
         // Billing module settings
         'modules:billing:enabled',

--- a/config/modules/auth/oidc.php
+++ b/config/modules/auth/oidc.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    /*
+     * Enable or disable OIDC SSO
+     */
+    'enabled' => env('OIDC_ENABLED', false),
+
+    /*
+     * OIDC Issuer URL (e.g. https://accounts.google.com or https://keycloak.example.com/realms/myrealm)
+     * The panel will fetch /.well-known/openid-configuration from this URL automatically.
+     */
+    'issuer_url' => env('OIDC_ISSUER_URL', ''),
+
+    /*
+     * OIDC Client ID
+     */
+    'client_id' => env('OIDC_CLIENT_ID', ''),
+
+    /*
+     * OIDC Client Secret
+     */
+    'client_secret' => env('OIDC_CLIENT_SECRET', ''),
+
+    /*
+     * Display name shown on the login button (defaults to "SSO")
+     */
+    'display_name' => env('OIDC_DISPLAY_NAME', 'SSO'),
+
+    /*
+     * Space-separated list of scopes to request (openid, email, and profile are always included)
+     */
+    'scopes' => env('OIDC_SCOPES', ''),
+];

--- a/config/modules/auth/oidc.php
+++ b/config/modules/auth/oidc.php
@@ -38,4 +38,14 @@ return [
      * Has no effect if OIDC SSO is not enabled.
      */
     'disable_local_login' => env('OIDC_DISABLE_LOCAL_LOGIN', false),
+
+    /*
+     * When enabled (the default), the panel will reject any OIDC login whose
+     * id_token / userinfo does not assert email_verified === true. Turn this
+     * off ONLY if your provider is known to not emit the claim *and* you fully
+     * trust it not to issue tokens with email addresses the user does not own —
+     * disabling it re-opens the account-takeover path where an attacker with an
+     * OIDC account at your IdP can claim an existing panel user's email.
+     */
+    'require_verified_email' => env('OIDC_REQUIRE_VERIFIED_EMAIL', true),
 ];

--- a/config/modules/auth/oidc.php
+++ b/config/modules/auth/oidc.php
@@ -48,4 +48,14 @@ return [
      * OIDC account at your IdP can claim an existing panel user's email.
      */
     'require_verified_email' => env('OIDC_REQUIRE_VERIFIED_EMAIL', true),
+
+    /*
+     * When enabled (the default), the panel verifies the TLS certificate on
+     * every outbound call to the OIDC provider (discovery, token endpoint,
+     * userinfo, JWKS). Turn this off ONLY for trusted internal IdPs that
+     * present a self-signed or otherwise non-trusted certificate — disabling
+     * it removes the only protection against an attacker who can MITM the
+     * panel → IdP connection (e.g. via a compromised intermediate proxy).
+     */
+    'verify_ssl' => env('OIDC_VERIFY_SSL', true),
 ];

--- a/config/modules/auth/oidc.php
+++ b/config/modules/auth/oidc.php
@@ -31,4 +31,11 @@ return [
      * Space-separated list of scopes to request (openid, email, and profile are always included)
      */
     'scopes' => env('OIDC_SCOPES', ''),
+
+    /*
+     * When enabled, the regular username/password login form will be hidden on the
+     * login page. Users will only be able to authenticate via this OIDC SSO module.
+     * Has no effect if OIDC SSO is not enabled.
+     */
+    'disable_local_login' => env('OIDC_DISABLE_LOCAL_LOGIN', false),
 ];

--- a/database/migrations/2026_05_15_120000_add_oidc_identity_to_users_table.php
+++ b/database/migrations/2026_05_15_120000_add_oidc_identity_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('oidc_iss', 191)->nullable()->after('external_id');
+            $table->string('oidc_sub', 191)->nullable()->after('oidc_iss');
+
+            // (iss, sub) is the stable, opaque identifier pair from OIDC. NULLs
+            // are allowed (non-OIDC users) and MySQL/MariaDB treat NULLs as
+            // distinct, so the uniqueness constraint only binds on linked rows.
+            $table->unique(['oidc_iss', 'oidc_sub'], 'users_oidc_iss_sub_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_oidc_iss_sub_unique');
+            $table->dropColumn(['oidc_iss', 'oidc_sub']);
+        });
+    }
+};

--- a/resources/scripts/api/routes/admin/auth/module.ts
+++ b/resources/scripts/api/routes/admin/auth/module.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export const toggleModule = (toggle: string, name: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/application/auth/modules/${toggle}`, name)
+        http.post(`/api/application/auth/modules/${toggle}`, { module: name })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/components/admin/modules/auth/AuthContainer.tsx
+++ b/resources/scripts/components/admin/modules/auth/AuthContainer.tsx
@@ -10,6 +10,7 @@ import { useStoreState } from '@/state/hooks';
 import DiscordSSO from './modules/DiscordSSO';
 import Onboarding from '@admin/modules/auth/modules/Onboarding';
 import GoogleSSO from './modules/GoogleSSO';
+import OidcSSO from './modules/OidcSSO';
 import JGuard from './modules/JGuard';
 
 export default () => {
@@ -52,6 +53,7 @@ export default () => {
                 {modules.jguard.enabled && <JGuard />}
                 {modules.discord.enabled && <DiscordSSO />}
                 {modules.google.enabled && <GoogleSSO />}
+                {modules.oidc.enabled && <OidcSSO />}
             </div>
         </AdminContentBlock>
     );

--- a/resources/scripts/components/admin/modules/auth/Modules.tsx
+++ b/resources/scripts/components/admin/modules/auth/Modules.tsx
@@ -3,6 +3,7 @@ import Box from '@/components/admin/modules/auth/Box';
 import { faDoorOpen, faShieldHalved } from '@fortawesome/free-solid-svg-icons';
 import FlashMessageRender from '@/elements/FlashMessageRender';
 import { faDiscord, faGoogle } from '@fortawesome/free-brands-svg-icons';
+import { faIdCard } from '@fortawesome/free-solid-svg-icons';
 
 export default () => {
     const modules = useStoreState(state => state.everest.data!.auth.modules);
@@ -50,6 +51,13 @@ export default () => {
                 title={'Google SSO'}
                 disabled={modules.google.enabled}
                 description={'This module allows users to sign up and login via the Google Auth API.'}
+            />
+            <Box
+                name={'oidc'}
+                icon={faIdCard}
+                title={'OIDC SSO'}
+                disabled={modules.oidc.enabled}
+                description={'This module allows users to sign up and login via any OIDC-compliant provider (Keycloak, Authentik, Authelia, Okta, Azure AD, etc.).'}
             />
         </>
     );

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -157,6 +157,18 @@ export default () => {
                 />
             </div>
 
+            <div className={'my-6'}>
+                <Switch
+                    name={'verify_ssl'}
+                    label={'Verify TLS Certificate'}
+                    description={
+                        'When enabled (recommended), the panel validates the TLS certificate on every outbound request to the OIDC provider. Turn this off ONLY for trusted internal IdPs presenting a self-signed certificate — disabling it removes the only protection against a man-in-the-middle between the panel host and your IdP.'
+                    }
+                    defaultChecked={settings.verifySsl}
+                    onChange={e => update('verify_ssl', e.target.checked ? 1 : 0)}
+                />
+            </div>
+
             <Alert type={'info'}>
                 <div>
                     Use the following Callback URL in your OIDC provider:

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import useFlash from '@/plugins/useFlash';
+import useStatus from '@/plugins/useStatus';
+import { useStoreState } from '@/state/hooks';
+import Label from '@/elements/Label';
+import Input from '@/elements/Input';
+import AdminBox from '@/elements/AdminBox';
+import { TrashIcon } from '@heroicons/react/outline';
+import { Dialog } from '@/elements/dialog';
+import { faIdCard } from '@fortawesome/free-solid-svg-icons';
+import FlashMessageRender from '@/elements/FlashMessageRender';
+import RequiredFieldIcon from '@/elements/RequiredFieldIcon';
+import { toggleModule, updateModule } from '@/api/routes/admin/auth/module';
+import { Alert } from '@/elements/alert';
+
+export default () => {
+    const { status, setStatus } = useStatus();
+    const [confirm, setConfirm] = useState<boolean>(false);
+    const { clearFlashes, clearAndAddHttpError } = useFlash();
+    const settings = useStoreState(state => state.everest.data!.auth.modules.oidc);
+
+    const update = async (key: string, value: any) => {
+        clearFlashes();
+        setStatus('loading');
+
+        updateModule('oidc', key, value)
+            .then(() => {
+                setStatus('success');
+            })
+            .catch(error => {
+                clearAndAddHttpError({ key: 'auth:modules:oidc', error });
+                setStatus('error');
+            });
+    };
+
+    const doDeletion = () => {
+        toggleModule('disable', 'oidc')
+            .then(() => {
+                // @ts-expect-error this is fine
+                window.location = '/admin/auth';
+            })
+            .catch(error => clearAndAddHttpError({ key: 'auth:modules:oidc', error }));
+    };
+
+    return (
+        <AdminBox title={'OIDC SSO Module'} icon={faIdCard} byKey={'auth:modules:oidc'} status={status} canDelete>
+            <FlashMessageRender byKey={'auth:modules:oidc'} className={'my-2'} />
+            <Dialog.Confirm
+                open={confirm}
+                title={'Confirm module removal'}
+                onConfirmed={() => doDeletion()}
+                onClose={() => setConfirm(false)}
+            >
+                Are you sure you wish to delete this module?
+            </Dialog.Confirm>
+            <TrashIcon
+                className={'w-5 h-5 absolute top-0 right-0 m-3.5 text-red-500 hover:text-red-300 duration-300'}
+                onClick={() => setConfirm(true)}
+            />
+
+            <div>
+                <Label>Issuer URL {!settings.issuerUrl && <RequiredFieldIcon />}</Label>
+                <Input
+                    autoComplete={'off'}
+                    id={'issuer_url'}
+                    type={'text'}
+                    name={'issuer_url'}
+                    onChange={e => update('issuer_url', e.target.value)}
+                    placeholder={settings.issuerUrl ? '(configured)' : 'https://accounts.example.com'}
+                />
+                <p className={'text-xs text-gray-400 mt-1'}>
+                    The base URL of your OIDC provider. The panel will auto-discover endpoints via{' '}
+                    <code>/.well-known/openid-configuration</code>. Examples: Keycloak, Authentik, Authelia, Okta,
+                    Azure AD, Google.
+                </p>
+            </div>
+
+            <div className={'my-6'}>
+                <Label>Client Identifier {!settings.clientId && <RequiredFieldIcon />}</Label>
+                <Input
+                    autoComplete={'off'}
+                    id={'client_id'}
+                    type={'password'}
+                    name={'client_id'}
+                    onChange={e => update('client_id', e.target.value)}
+                    placeholder={settings.clientId ? '••••••••••••••••' : ''}
+                />
+                <p className={'text-xs text-gray-400 mt-1'}>The Client ID from your OIDC provider.</p>
+            </div>
+
+            <div className={'my-6'}>
+                <Label>Client Secret {!settings.clientSecret && <RequiredFieldIcon />}</Label>
+                <Input
+                    autoComplete={'off'}
+                    id={'client_secret'}
+                    type={'password'}
+                    name={'client_secret'}
+                    onChange={e => update('client_secret', e.target.value)}
+                    placeholder={settings.clientSecret ? '••••••••••••••••' : ''}
+                />
+                <p className={'text-xs text-gray-400 mt-1'}>The Client Secret from your OIDC provider.</p>
+            </div>
+
+            <div className={'my-6'}>
+                <Label>Button Display Name</Label>
+                <Input
+                    autoComplete={'off'}
+                    id={'display_name'}
+                    type={'text'}
+                    name={'display_name'}
+                    onChange={e => update('display_name', e.target.value)}
+                    placeholder={settings.displayName || 'SSO'}
+                />
+                <p className={'text-xs text-gray-400 mt-1'}>
+                    The label shown on the login button (e.g. "Login with Keycloak").
+                </p>
+            </div>
+
+            <div className={'my-6'}>
+                <Label>Extra Scopes</Label>
+                <Input
+                    autoComplete={'off'}
+                    id={'scopes'}
+                    type={'text'}
+                    name={'scopes'}
+                    onChange={e => update('scopes', e.target.value)}
+                    placeholder={'groups roles'}
+                />
+                <p className={'text-xs text-gray-400 mt-1'}>
+                    Space-separated list of additional scopes to request. <code>openid email profile</code> are always
+                    included.
+                </p>
+            </div>
+
+            <Alert type={'info'}>
+                <div>
+                    Use the following Callback URL in your OIDC provider:
+                    <p className={'bg-black/50 p-1 rounded-lg font-mono w-fit mt-2'}>
+                        /auth/modules/oidc/authenticate
+                    </p>
+                </div>
+            </Alert>
+        </AdminBox>
+    );
+};

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -136,7 +136,7 @@ export default () => {
                 <div>
                     Use the following Callback URL in your OIDC provider:
                     <p className={'bg-black/50 p-1 rounded-lg font-mono w-fit mt-2'}>
-                        /auth/modules/oidc/authenticate
+                        {settings.callbackUrl}
                     </p>
                 </div>
             </Alert>

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -4,7 +4,7 @@ import useStatus from '@/plugins/useStatus';
 import { useStoreState } from '@/state/hooks';
 import Label from '@/elements/Label';
 import Input from '@/elements/Input';
-import Select from '@/elements/Select';
+import Switch from '@/elements/Switch';
 import AdminBox from '@/elements/AdminBox';
 import { TrashIcon } from '@heroicons/react/outline';
 import { Dialog } from '@/elements/dialog';
@@ -134,24 +134,15 @@ export default () => {
             </div>
 
             <div className={'my-6'}>
-                <Label>Disable Local Login</Label>
-                <Select
-                    id={'disable_local_login'}
+                <Switch
                     name={'disable_local_login'}
-                    onChange={e => update('disable_local_login', e.target.value)}
-                    autoComplete={'off'}
-                >
-                    <option value={1} selected={settings.disableLocalLogin}>
-                        Enabled
-                    </option>
-                    <option value={0} selected={!settings.disableLocalLogin}>
-                        Disabled
-                    </option>
-                </Select>
-                <p className={'text-xs text-gray-400 mt-1'}>
-                    When enabled, the username/password login form will be hidden. Users will only be able to
-                    authenticate via this OIDC SSO module.
-                </p>
+                    label={'Disable Local Login'}
+                    description={
+                        'When enabled, the username/password login form will be hidden. Users will only be able to authenticate via this OIDC SSO module.'
+                    }
+                    defaultChecked={settings.disableLocalLogin}
+                    onChange={e => update('disable_local_login', e.target.checked ? 1 : 0)}
+                />
             </div>
 
             <Alert type={'info'}>

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -4,6 +4,7 @@ import useStatus from '@/plugins/useStatus';
 import { useStoreState } from '@/state/hooks';
 import Label from '@/elements/Label';
 import Input from '@/elements/Input';
+import Select from '@/elements/Select';
 import AdminBox from '@/elements/AdminBox';
 import { TrashIcon } from '@heroicons/react/outline';
 import { Dialog } from '@/elements/dialog';
@@ -129,6 +130,27 @@ export default () => {
                 <p className={'text-xs text-gray-400 mt-1'}>
                     Space-separated list of additional scopes to request. <code>openid email profile</code> are always
                     included.
+                </p>
+            </div>
+
+            <div className={'my-6'}>
+                <Label>Disable Local Login</Label>
+                <Select
+                    id={'disable_local_login'}
+                    name={'disable_local_login'}
+                    onChange={e => update('disable_local_login', e.target.value)}
+                    autoComplete={'off'}
+                >
+                    <option value={1} selected={settings.disableLocalLogin}>
+                        Enabled
+                    </option>
+                    <option value={0} selected={!settings.disableLocalLogin}>
+                        Disabled
+                    </option>
+                </Select>
+                <p className={'text-xs text-gray-400 mt-1'}>
+                    When enabled, the username/password login form will be hidden. Users will only be able to
+                    authenticate via this OIDC SSO module.
                 </p>
             </div>
 

--- a/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
+++ b/resources/scripts/components/admin/modules/auth/modules/OidcSSO.tsx
@@ -145,6 +145,18 @@ export default () => {
                 />
             </div>
 
+            <div className={'my-6'}>
+                <Switch
+                    name={'require_verified_email'}
+                    label={'Require Verified Email'}
+                    description={
+                        'When enabled (recommended), the panel rejects any OIDC login whose provider does not assert email_verified=true. Turn this off ONLY if your provider does not emit the claim and you fully trust it not to issue tokens for emails the user does not own — disabling it re-opens the account-takeover path where an attacker with an account at your IdP can claim an existing panel user’s email.'
+                    }
+                    defaultChecked={settings.requireVerifiedEmail}
+                    onChange={e => update('require_verified_email', e.target.checked ? 1 : 0)}
+                />
+            </div>
+
             <Alert type={'info'}>
                 <div>
                     Use the following Callback URL in your OIDC provider:

--- a/resources/scripts/components/auth/LoginCheckpointContainer.tsx
+++ b/resources/scripts/components/auth/LoginCheckpointContainer.tsx
@@ -68,9 +68,12 @@ function LoginCheckpointContainer() {
     );
 }
 
+const tokenFromLocation = (location: Location): string =>
+    location.state?.token || new URLSearchParams(location.search).get('token') || '';
+
 const EnhancedForm = withFormik<Props & { location: Location }, Values>({
     handleSubmit: ({ code, recoveryCode }, { setSubmitting, props: { clearAndAddHttpError, location } }) => {
-        checkpoint(location.state?.token || '', code, recoveryCode)
+        checkpoint(tokenFromLocation(location), code, recoveryCode)
             .then(response => {
                 if (response.complete) {
                     // @ts-expect-error this is valid
@@ -99,7 +102,7 @@ export default ({ ...props }: OwnProps) => {
     const location = useLocation();
     const navigate = useNavigate();
 
-    if (!location.state?.token) {
+    if (!tokenFromLocation(location)) {
         navigate('/auth/login');
 
         return null;

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -108,44 +108,48 @@ function LoginContainer() {
         >
             {({ isSubmitting, setSubmitting, submitForm }) => (
                 <LoginFormContainer title={`Welcome to ${appName}`}>
-                    <Field
-                        icon={faAt}
-                        type={'text'}
-                        label={'Username or Email'}
-                        name={'username'}
-                        disabled={isSubmitting}
-                        placeholder={'user@jexpanel.com'}
-                    />
-                    <div css={tw`mt-6`}>
-                        <Label>
-                            Password
-                            <Link
-                                to={'/auth/password'}
-                                tabIndex={-1}
-                                className={'ml-1 text-green-400 hover:text-green-200 duration-300 text-xs'}
-                            >
-                                Forgot Password?
-                            </Link>
-                        </Label>
-                        <Field
-                            icon={faKey}
-                            type={'password'}
-                            name={'password'}
-                            disabled={isSubmitting}
-                            placeholder={'••••••••••••'}
-                        />
-                    </div>
-                    <div css={tw`mt-6`}>
-                        <Button
-                            type={'submit'}
-                            loading={isSubmitting}
-                            className={'w-full'}
-                            size={Button.Sizes.Large}
-                            disabled={isSubmitting}
-                        >
-                            Login
-                        </Button>
-                    </div>
+                    {!modules.oidc.disableLocalLogin && (
+                        <>
+                            <Field
+                                icon={faAt}
+                                type={'text'}
+                                label={'Username or Email'}
+                                name={'username'}
+                                disabled={isSubmitting}
+                                placeholder={'user@jexpanel.com'}
+                            />
+                            <div css={tw`mt-6`}>
+                                <Label>
+                                    Password
+                                    <Link
+                                        to={'/auth/password'}
+                                        tabIndex={-1}
+                                        className={'ml-1 text-green-400 hover:text-green-200 duration-300 text-xs'}
+                                    >
+                                        Forgot Password?
+                                    </Link>
+                                </Label>
+                                <Field
+                                    icon={faKey}
+                                    type={'password'}
+                                    name={'password'}
+                                    disabled={isSubmitting}
+                                    placeholder={'••••••••••••'}
+                                />
+                            </div>
+                            <div css={tw`mt-6`}>
+                                <Button
+                                    type={'submit'}
+                                    loading={isSubmitting}
+                                    className={'w-full'}
+                                    size={Button.Sizes.Large}
+                                    disabled={isSubmitting}
+                                >
+                                    Login
+                                </Button>
+                            </div>
+                        </>
+                    )}
                     {recaptchaEnabled && (
                         <Reaptcha
                             ref={ref}

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -15,7 +15,7 @@ import useFlash from '@/plugins/useFlash';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDiscord, faGoogle } from '@fortawesome/free-brands-svg-icons';
 import Label from '@/elements/Label';
-import { faAt, faEnvelope, faKey } from '@fortawesome/free-solid-svg-icons';
+import { faAt, faEnvelope, faKey, faIdCard } from '@fortawesome/free-solid-svg-icons';
 
 interface Values {
     username: string;
@@ -159,7 +159,7 @@ function LoginContainer() {
                             }}
                         />
                     )}
-                    {(modules.discord.enabled || modules.google.enabled || registration) && (
+                    {(modules.discord.enabled || modules.google.enabled || modules.oidc.enabled || registration) && (
                         <div className={'w-full text-center my-3 text-gray-400'}>OR</div>
                     )}
                     <div className={'mt-4 w-full grid gap-4 grid-cols-2'}>
@@ -171,6 +171,12 @@ function LoginContainer() {
                         {modules.google.enabled && (
                             <Button.Text type={'button'} onClick={() => useOauth('google')} size={Button.Sizes.Small}>
                                 <FontAwesomeIcon icon={faGoogle} className={'mr-2 my-auto'} /> Use Google SSO
+                            </Button.Text>
+                        )}
+                        {modules.oidc.enabled && (
+                            <Button.Text type={'button'} onClick={() => useOauth('oidc')} size={Button.Sizes.Small}>
+                                <FontAwesomeIcon icon={faIdCard} className={'mr-2 my-auto'} />{' '}
+                                {modules.oidc.displayName || 'Use SSO'}
                             </Button.Text>
                         )}
                         {registration && (

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -25,6 +25,7 @@ interface Values {
 function LoginContainer() {
     const ref = useRef<Reaptcha>(null);
     const token = useRef('');
+    const pendingOauth = useRef<string | null>(null);
 
     const appName = useStoreState(state => state.settings.data!.name);
     const modules = useStoreState(state => state.everest.data!.auth.modules);
@@ -39,21 +40,27 @@ function LoginContainer() {
         clearFlashes();
     }, []);
 
-    const useOauth = (name: string) => {
-        if (recaptchaEnabled && !token.current) {
-            ref.current!.execute().catch(error => {
-                console.error(error);
-                clearAndAddHttpError({ error });
-            });
-            return;
-        }
-
+    const startOauth = (name: string) => {
         externalLogin(name, token.current)
             .then(url => {
                 // @ts-expect-error this is fine
                 window.location = url;
             })
             .catch(error => clearAndAddHttpError({ key: 'auth:register', error }));
+    };
+
+    const useOauth = (name: string) => {
+        if (recaptchaEnabled && !token.current) {
+            pendingOauth.current = name;
+            ref.current!.execute().catch(error => {
+                console.error(error);
+                pendingOauth.current = null;
+                clearAndAddHttpError({ error });
+            });
+            return;
+        }
+
+        startOauth(name);
     };
 
     const onSubmit = (values: Values, { setSubmitting }: FormikHelpers<Values>) => {
@@ -146,7 +153,13 @@ function LoginContainer() {
                             sitekey={siteKey || '_invalid_key'}
                             onVerify={response => {
                                 token.current = response;
-                                submitForm();
+                                if (pendingOauth.current) {
+                                    const name = pendingOauth.current;
+                                    pendingOauth.current = null;
+                                    startOauth(name);
+                                } else {
+                                    submitForm();
+                                }
                             }}
                             onExpire={() => {
                                 setSubmitting(false);

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -43,10 +43,8 @@ function LoginContainer() {
         if (recaptchaEnabled && !token.current) {
             ref.current!.execute().catch(error => {
                 console.error(error);
-
                 clearAndAddHttpError({ error });
             });
-
             return;
         }
 
@@ -61,16 +59,12 @@ function LoginContainer() {
     const onSubmit = (values: Values, { setSubmitting }: FormikHelpers<Values>) => {
         clearFlashes();
 
-        // If there is no token in the state yet, request the token and then abort this submit request
-        // since it will be re-submitted when the recaptcha data is returned by the component.
         if (recaptchaEnabled && !token.current) {
             ref.current!.execute().catch(error => {
                 console.error(error);
-
                 setSubmitting(false);
                 clearAndAddHttpError({ error });
             });
-
             return;
         }
 
@@ -81,19 +75,20 @@ function LoginContainer() {
                     window.location = response.intended || '/';
                     return;
                 }
-
                 navigate('/auth/login/checkpoint', { state: { token: response.confirmationToken } });
             })
             .catch(error => {
                 console.error(error);
-
                 token.current = '';
                 if (ref.current) ref.current.reset();
-
                 setSubmitting(false);
                 clearAndAddHttpError({ error });
             });
     };
+
+    // Count enabled SSO/registration buttons to pick the right grid layout.
+    const oauthButtons = [modules.discord.enabled, modules.google.enabled, modules.oidc.enabled, registration].filter(Boolean);
+    const gridCols = oauthButtons.length === 1 ? 'grid-cols-1' : 'grid-cols-2';
 
     return (
         <Formik
@@ -159,10 +154,10 @@ function LoginContainer() {
                             }}
                         />
                     )}
-                    {(modules.discord.enabled || modules.google.enabled || modules.oidc.enabled || registration) && (
+                    {oauthButtons.length > 0 && (
                         <div className={'w-full text-center my-3 text-gray-400'}>OR</div>
                     )}
-                    <div className={'mt-4 w-full grid gap-4 grid-cols-2'}>
+                    <div className={`mt-4 w-full grid gap-4 ${gridCols}`}>
                         {modules.discord.enabled && (
                             <Button.Info type={'button'} onClick={() => useOauth('discord')} size={Button.Sizes.Small}>
                                 <FontAwesomeIcon icon={faDiscord} className={'mr-2 my-auto'} /> Use Discord SSO

--- a/resources/scripts/components/auth/LoginContainer.tsx
+++ b/resources/scripts/components/auth/LoginContainer.tsx
@@ -171,7 +171,7 @@ function LoginContainer() {
                             }}
                         />
                     )}
-                    {oauthButtons.length > 0 && (
+                    {oauthButtons.length > 0 && !modules.oidc.disableLocalLogin && (
                         <div className={'w-full text-center my-3 text-gray-400'}>OR</div>
                     )}
                     <div className={`mt-4 w-full grid gap-4 ${gridCols}`}>

--- a/resources/scripts/state/everest.ts
+++ b/resources/scripts/state/everest.ts
@@ -34,6 +34,7 @@ export interface EverestSettings {
                 clientSecret: boolean;
                 displayName: string;
                 disableLocalLogin: boolean;
+                requireVerifiedEmail: boolean;
                 callbackUrl: string;
             };
             onboarding: {

--- a/resources/scripts/state/everest.ts
+++ b/resources/scripts/state/everest.ts
@@ -27,6 +27,13 @@ export interface EverestSettings {
                 clientId: boolean;
                 clientSecret: boolean;
             };
+            oidc: {
+                enabled: boolean;
+                issuerUrl: boolean;
+                clientId: boolean;
+                clientSecret: boolean;
+                displayName: string;
+            };
             onboarding: {
                 enabled: boolean;
                 content?: string;

--- a/resources/scripts/state/everest.ts
+++ b/resources/scripts/state/everest.ts
@@ -33,6 +33,7 @@ export interface EverestSettings {
                 clientId: boolean;
                 clientSecret: boolean;
                 displayName: string;
+                callbackUrl: string;
             };
             onboarding: {
                 enabled: boolean;

--- a/resources/scripts/state/everest.ts
+++ b/resources/scripts/state/everest.ts
@@ -33,6 +33,7 @@ export interface EverestSettings {
                 clientId: boolean;
                 clientSecret: boolean;
                 displayName: string;
+                disableLocalLogin: boolean;
                 callbackUrl: string;
             };
             onboarding: {

--- a/resources/scripts/state/everest.ts
+++ b/resources/scripts/state/everest.ts
@@ -35,6 +35,7 @@ export interface EverestSettings {
                 displayName: string;
                 disableLocalLogin: boolean;
                 requireVerifiedEmail: boolean;
+                verifySsl: boolean;
                 callbackUrl: string;
             };
             onboarding: {

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -39,6 +39,10 @@ Route::middleware(['throttle:authentication'])->group(function () {
         ->middleware('recaptcha')
         ->name('auth.modules.google.authenticate');
 
+    Route::post('/modules/oidc', [Auth\Modules\OidcLoginController::class, 'requestToken'])->middleware('recaptcha');
+    Route::get('/modules/oidc/authenticate', [Auth\Modules\OidcLoginController::class, 'authenticate'])
+        ->name('auth.modules.oidc.authenticate');
+
     // Forgot password route. A post to this endpoint will trigger an
     // email to be sent containing a reset token.
     Route::post('/password', [Auth\ForgotPasswordController::class, 'verify'])

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -40,7 +40,7 @@ Route::middleware(['throttle:authentication'])->group(function () {
         ->name('auth.modules.google.authenticate');
 
     Route::post('/modules/oidc', [Auth\Modules\OidcLoginController::class, 'requestToken'])->middleware('recaptcha');
-    Route::get('/modules/oidc/authenticate', [Auth\Modules\OidcLoginController::class, 'authenticate'])
+    Route::match(['get', 'post'], '/modules/oidc/authenticate', [Auth\Modules\OidcLoginController::class, 'authenticate'])
         ->name('auth.modules.oidc.authenticate');
 
     // Forgot password route. A post to this endpoint will trigger an


### PR DESCRIPTION
OIDC SSO (the main feature)
    - New config/modules/auth/oidc.php — env-driven config (OIDC_ENABLED, OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISPLAY_NAME, OIDC_SCOPES).
    - New OidcLoginController — auto-discovers endpoints from /.well-known/openid-configuration, runs the standard authorization_code flow with CSRF state protection, accepts callbacks via either GET or POST (form_post mode), pulls email + preferred_username from userinfo or id_token, sanitises the username to satisfy panel rules, creates accounts directly via UserCreationService so the public registration toggle doesn't block OIDC, then logs the user in via the web guard with proper session regeneration.
    - Routes added in routes/auth.php: POST /auth/modules/oidc and GET|POST /auth/modules/oidc/authenticate.
    - EverestComposer and SettingsServiceProvider updated to expose and persist the OIDC settings.
    - New admin UI panel OidcSSO.tsx for issuer URL, credentials, display name, scopes — and shows the full callback URL built from APP_URL.
    - LoginContainer.tsx adds the OIDC login button with the configurable display label, and adapts grid layout (grid-cols-1 for one button, grid-cols-2 for more).
    - AuthContainer.tsx, Modules.tsx, state/everest.ts extended with the new module.
    
Latent bug fixes uncovered while testing (all from a pre-existing refactor, commit 3124260a1)
    - ApplicationApiController::returnNoContent() was infinitely recursive — every endpoint returning 204 (module enable/disable, account password change, subuser delete, etc.) crashed with stack overflow. Fixed to actually return a 204 response.
    - ClientApiController::getIncludesForTransformer() was typed to take a Transformer instance but every caller passes a class-name string — GET /api/client (post-login server list) crashed with TypeError. Fixed to accept either.
    - ResourceUtilizationController was passing a plain PHP stats array to the transform() helper, which iterated it as a collection. Caused 500 on every server resources poll — making all servers appear offline. Fixed to call fractal->item() directly.
    - ModuleController::enable/disable read $request->all()[0], which was unreliable. Frontend toggleModule was sending a bare string body. Fixed both sides to use { module: name } JSON and $request->input('module').