### PR TITLE
Add JWT scope enum and node token scopes

### DIFF
--- a/app/Enum/JwtScope.php
+++ b/app/Enum/JwtScope.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jexactyl\Enum;
+
+enum JwtScope: string
+{
+    case Websocket = 'websocket';
+    case FileUpload = 'file-upload';
+    case FileDownload = 'file-download';
+    case BackupDownload = 'backup-download';
+    case ServerTransfer = 'transfer';
+}

--- a/app/Http/Controllers/Admin/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Admin/Servers/ServerTransferController.php
@@ -3,6 +3,7 @@
 namespace Jexactyl\Http\Controllers\Admin\Servers;
 
 use Carbon\CarbonImmutable;
+use Jexactyl\Enum\JwtScope;
 use Jexactyl\Models\Server;
 use Illuminate\Http\Request;
 use Jexactyl\Models\ServerTransfer;
@@ -78,6 +79,7 @@ class ServerTransferController extends Controller
             $token = $this->nodeJWTService
                 ->setExpiresAt(CarbonImmutable::now()->addMinutes(15))
                 ->setSubject($server->uuid)
+                ->setScopes(JwtScope::ServerTransfer)
                 ->handle($transfer->newNode, $server->uuid, 'sha256');
 
             // Notify the source node of the pending outgoing transfer.

--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -3,6 +3,7 @@
 namespace Jexactyl\Http\Controllers\Api\Client\Servers;
 
 use Carbon\CarbonImmutable;
+use Jexactyl\Enum\JwtScope;
 use Jexactyl\Models\Server;
 use Illuminate\Http\Response;
 use Jexactyl\Facades\Activity;
@@ -83,6 +84,7 @@ class FileController extends ClientApiController
                 'file_path' => rawurldecode($request->get('file')),
                 'server_uuid' => $server->uuid,
             ])
+            ->setScopes(JwtScope::FileDownload)
             ->handle($server->node, $request->user()->id . $server->uuid);
 
         Activity::event('server:file.download')->property('file', $request->get('file'))->log();

--- a/app/Http/Controllers/Api/Client/Servers/FileUploadController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileUploadController.php
@@ -4,6 +4,7 @@ namespace Jexactyl\Http\Controllers\Api\Client\Servers;
 
 use Jexactyl\Models\User;
 use Carbon\CarbonImmutable;
+use Jexactyl\Enum\JwtScope;
 use Jexactyl\Models\Server;
 use Illuminate\Http\JsonResponse;
 use Jexactyl\Services\Nodes\NodeJWTService;
@@ -43,6 +44,7 @@ class FileUploadController extends ClientApiController
             ->setExpiresAt(CarbonImmutable::now()->addMinutes(15))
             ->setUser($user)
             ->setClaims(['server_uuid' => $server->uuid])
+            ->setScopes(JwtScope::FileUpload)
             ->handle($server->node, $user->id . $server->uuid);
 
         return sprintf(

--- a/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
+++ b/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
@@ -3,6 +3,7 @@
 namespace Jexactyl\Http\Controllers\Api\Client\Servers;
 
 use Carbon\CarbonImmutable;
+use Jexactyl\Enum\JwtScope;
 use Jexactyl\Models\Server;
 use Jexactyl\Models\Permission;
 use Illuminate\Http\JsonResponse;
@@ -59,6 +60,7 @@ class WebsocketController extends ClientApiController
                 'server_uuid' => $server->uuid,
                 'permissions' => $permissions,
             ])
+            ->setScopes(JwtScope::Websocket)
             ->handle($node, $user->id . $server->uuid);
 
         $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $node->getConnectionAddress());

--- a/app/Services/Backups/DownloadLinkService.php
+++ b/app/Services/Backups/DownloadLinkService.php
@@ -4,6 +4,7 @@ namespace Jexactyl\Services\Backups;
 
 use Jexactyl\Models\User;
 use Carbon\CarbonImmutable;
+use Jexactyl\Enum\JwtScope;
 use Jexactyl\Models\Backup;
 use Jexactyl\Services\Nodes\NodeJWTService;
 use Jexactyl\Extensions\Backups\BackupManager;
@@ -34,6 +35,7 @@ class DownloadLinkService
                 'backup_uuid' => $backup->uuid,
                 'server_uuid' => $backup->server->uuid,
             ])
+            ->setScopes(JwtScope::BackupDownload)
             ->handle($backup->server->node, $user->id . $backup->server->uuid);
 
         return sprintf('%s/download/backup?token=%s', $backup->server->node->getConnectionAddress(), $token->toString());

--- a/app/Services/Nodes/NodeJWTService.php
+++ b/app/Services/Nodes/NodeJWTService.php
@@ -6,6 +6,7 @@ use Jexactyl\Models\Node;
 use Jexactyl\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Str;
+use Jexactyl\Enum\JwtScope;
 use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
@@ -15,6 +16,8 @@ use Jexactyl\Extensions\Lcobucci\JWT\Encoding\TimestampDates;
 class NodeJWTService
 {
     private array $claims = [];
+
+    private array $scopes = [];
 
     private ?User $user = null;
 
@@ -28,6 +31,18 @@ class NodeJWTService
     public function setClaims(array $claims): self
     {
         $this->claims = $claims;
+
+        return $this;
+    }
+
+    /**
+     * Set the scopes that this JWT is valid for. Wings (1.12.0+) requires a matching
+     * "scope" claim on every JWT it receives, so this must be set for the daemon to
+     * accept the token (e.g. when authenticating a websocket connection).
+     */
+    public function setScopes(JwtScope ...$scopes): self
+    {
+        $this->scopes = $scopes;
 
         return $this;
     }
@@ -83,6 +98,13 @@ class NodeJWTService
 
         foreach ($this->claims as $key => $value) {
             $builder = $builder->withClaim($key, $value);
+        }
+
+        // Wings validates a space-delimited "scope" claim on every JWT it receives.
+        // Without it, requests such as websocket authentication are rejected with
+        // "There was an error validating the credentials provided for the websocket."
+        if (!empty($this->scopes)) {
+            $builder = $builder->withClaim('scope', implode(' ', array_map(fn (JwtScope $scope) => $scope->value, $this->scopes)));
         }
 
         if (!is_null($this->user)) {


### PR DESCRIPTION
Introduce a JwtScope enum and add support for setting scopes on node JWTs. Adds app/Enum/JwtScope with cases for websocket, file-upload, file-download, backup-download and transfer. Update controllers and services (ServerTransferController, FileController, FileUploadController, WebsocketController, DownloadLinkService) to call setScopes(...) when generating tokens. NodeJWTService now stores JwtScope values via setScopes(JwtScope...), and injects a space-delimited "scope" claim into the token so the Wings daemon will accept websocket, file and backup-related requests.