### PR TITLE
fix: add missing websocket scope claim to JWT token

### DIFF
--- a/app/Services/Nodes/NodeJWTService.php
+++ b/app/Services/Nodes/NodeJWTService.php
@@ -98,6 +98,7 @@ class NodeJWTService
 
         return $builder
             ->withClaim('unique_id', Str::random())
+            ->withClaim('scope', 'websocket') 
             ->getToken($config->signer(), $config->signingKey());
     }
 }


### PR DESCRIPTION
Wings v1.11+ requires the JWT token to include a 'scope' claim  with value 'websocket' for WebSocket authentication to succeed.

Without this claim, Wings returns "jwt: missing connect permission" even when websocket.connect permission is present in the token.

Fixed by adding ->withClaim('scope', 'websocket') to NodeJWTService.