### PR TITLE
Fix invisible reCAPTCHA token check

### DIFF
--- a/resources/scripts/components/auth/ForgotPasswordContainer.tsx
+++ b/resources/scripts/components/auth/ForgotPasswordContainer.tsx
@@ -39,7 +39,7 @@ function ForgotPasswordContainer() {
 
         // If there is no token in the state yet, request the token and then abort this submit request
         // since it will be re-submitted when the recaptcha data is returned by the component.
-        if (recaptchaEnabled && !token) {
+        if (recaptchaEnabled && !token.current) {
             ref.current!.execute().catch(error => {
                 console.error(error);
 

--- a/resources/scripts/components/auth/RegisterContainer.tsx
+++ b/resources/scripts/components/auth/RegisterContainer.tsx
@@ -38,7 +38,7 @@ function RegisterContainer() {
 
         // If there is no token in the state yet, request the token and then abort this submit request
         // since it will be re-submitted when the recaptcha data is returned by the component.
-        if (recaptchaEnabled && !token) {
+        if (recaptchaEnabled && !token.current) {
             ref.current!.execute().catch(error => {
                 console.error(error);
 


### PR DESCRIPTION
## Summary

This fixes an issue where invisible reCAPTCHA never executes on the Register and Forgot Password pages.

The current implementation checks the ref object instead of its current value:

```tsx
if (recaptchaEnabled && !token) {
```

Since `token` is a React `useRef`, the ref object itself is always truthy, preventing `execute()` from ever being called.

As a result, the frontend submits an empty `g-recaptcha-response`, causing the backend to return:

```
Missing ReCaptcha token
```

## Changes

Updated the condition in:

- resources/scripts/components/auth/RegisterContainer.tsx
- resources/scripts/components/auth/ForgotPasswordContainer.tsx

From:

```tsx
if (recaptchaEnabled && !token) {
```

To:

```tsx
if (recaptchaEnabled && !token.current) {
```

## Testing

Tested on a fresh Jexactyl installation with Invisible reCAPTCHA v2 enabled.

- Registration now correctly calls `execute()`.
- A valid reCAPTCHA token is generated.
- User registration completes successfully.