### PR TITLE
fix(ui): improve mobile navigation layout

### DIFF
--- a/resources/scripts/assets/css/GlobalStylesheet.ts
+++ b/resources/scripts/assets/css/GlobalStylesheet.ts
@@ -19,8 +19,13 @@ export default createGlobalStyle`
         ${tw`m-0`};
     }
 
-    textarea, select, input, button, button:focus, button:focus-visible {
+    textarea, select, input, button {
         ${tw`outline-none`};
+    }
+
+    :focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
     }
 
     input[type=number]::-webkit-outer-spin-button,

--- a/resources/scripts/elements/MobileSidebar.tsx
+++ b/resources/scripts/elements/MobileSidebar.tsx
@@ -1,4 +1,4 @@
-import { ElementType, ReactNode, useState } from 'react';
+import { ElementType, ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useStoreState } from '@/state/hooks';
@@ -7,9 +7,14 @@ import { withSubComponents } from '@/lib/helpers';
 
 const MobileSidebar = ({ children }: { children: ReactNode[] }) => {
     return (
-        <div className={'block md:hidden w-full fixed bottom-0 h-16 z-50 rounded-t-xl bg-black/80'}>
-            <div className={'flex h-full px-8 space-x-8 overflow-x-auto'}>{children}</div>
-        </div>
+        <nav
+            aria-label={'Mobile navigation'}
+            className={
+                'fixed inset-x-0 bottom-0 z-50 block border-t border-white/10 bg-black/90 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden'
+            }
+        >
+            <div className={'flex h-16 items-stretch gap-1 overflow-x-auto overscroll-x-contain px-2'}>{children}</div>
+        </nav>
     );
 };
 
@@ -24,22 +29,22 @@ const Link = ({
     linkTo: string;
     end?: boolean;
 }) => {
-    const [active, setActive] = useState<boolean>(false);
     const { colors } = useStoreState(s => s.theme.data!);
 
     return (
         <NavLink
             to={linkTo}
             end={end}
+            aria-label={text}
             className={({ isActive }) =>
-                `h-full flex items-center justify-center font-semibold transition duration-300 ${
-                    isActive ? setActive(true) : setActive(false)
+                `flex min-w-[4.5rem] flex-1 flex-col items-center justify-center gap-1 px-2 text-xs font-semibold transition-colors duration-200 ${
+                    isActive ? 'bg-white/10' : 'text-neutral-300'
                 }`
             }
-            style={{ color: active ? colors.primary : '' }}
+            style={({ isActive }) => ({ color: isActive ? colors.primary : undefined })}
         >
-            {Icon && <Icon className={'w-4 h-4 mr-2'} />}
-            {text}
+            {Icon && <Icon aria-hidden={'true'} className={'h-5 w-5 shrink-0'} />}
+            {text && <span className={'max-w-[5rem] truncate'}>{text}</span>}
         </NavLink>
     );
 };
@@ -48,12 +53,10 @@ const Home = () => {
     const { colors } = useStoreState(s => s.theme.data!);
     return (
         <>
-            <NavLink to={'/'}>
-                <div className={'h-full flex items-center justify-center font-semibold my-auto'}>
-                    <FontAwesomeIcon icon={faHome} style={{ color: colors.primary }} className={'brightness-150'} />
-                </div>
+            <NavLink to={'/'} aria-label={'Dashboard'} className={'flex min-w-12 items-center justify-center px-3'}>
+                <FontAwesomeIcon icon={faHome} style={{ color: colors.primary }} className={'h-5 w-5 brightness-150'} />
             </NavLink>
-            <div className={'mx-3 my-auto'}>&bull;</div>
+            <div aria-hidden={'true'} className={'my-4 w-px shrink-0 bg-white/20'} />
         </>
     );
 };

--- a/resources/scripts/elements/NavigationBar.tsx
+++ b/resources/scripts/elements/NavigationBar.tsx
@@ -54,17 +54,17 @@ const NavigationBar = () => {
     }, []);
 
     const renderBreadcrumbs = () => (
-        <ol className="w-1/3 text-gray-400 text-sm inline-flex space-x-2">
+        <ol className="flex min-w-0 flex-1 items-center space-x-2 overflow-hidden text-sm text-gray-400">
             <Link to={'/'}>
                 <HomeIcon className="w-4 h-4 my-auto brightness-150" />
             </Link>
             {pathnames.map((segment, index) => {
                 const href = `/${pathnames.slice(0, index + 1).join('/')}`;
                 return (
-                    <li key={index} className="inline-flex">
+                    <li key={index} className="inline-flex min-w-0 items-center">
                         <ChevronRightIcon className="mr-2 w-4 h-4 my-auto" />
                         {index === pathnames.length - 1 ? (
-                            <span className="capitalize">{segment}</span>
+                            <span className="truncate capitalize">{segment}</span>
                         ) : (
                             <Link to={href} className="capitalize brightness-150">
                                 {segment}
@@ -117,10 +117,10 @@ const NavigationBar = () => {
     };
 
     return (
-        <div className="w-full overflow-x-auto shadow-md mb-8" style={{ backgroundColor: theme.colors.sidebar }}>
-            <div className="px-8 flex h-[3.5rem] w-full items-center">
+        <div className="mb-4 w-full shadow-md sm:mb-8" style={{ backgroundColor: theme.colors.sidebar }}>
+            <div className="flex h-14 w-full min-w-0 items-center gap-2 px-3 sm:px-8">
                 {renderBreadcrumbs()}
-                <RightNavigation className="flex h-full items-center justify-center ml-auto" theme={theme}>
+                <RightNavigation className="ml-auto flex h-full shrink-0 items-center justify-center" theme={theme}>
                     <div className="relative">
                         <div
                             className="absolute top-0 h-px transition-all duration-[250ms] ease-in-out"

--- a/resources/scripts/routers/AdminRouter.tsx
+++ b/resources/scripts/routers/AdminRouter.tsx
@@ -99,7 +99,11 @@ function AdminRouter() {
                     </div>
                 </Sidebar.User>
             </Sidebar>
-            <div className={'flex-1 overflow-x-hidden px-6 pt-6 lg:px-10 lg:pt-8 xl:px-16 xl:pt-12'}>
+            <main
+                className={
+                    'min-w-0 flex-1 overflow-x-hidden px-4 pt-4 pb-[calc(4rem+env(safe-area-inset-bottom))] sm:px-6 sm:pt-6 md:pb-6 lg:px-10 lg:pt-8 xl:px-16 xl:pt-12'
+                }
+            >
                 <div className={'w-full flex flex-col mx-auto'} style={{ maxWidth: '86rem' }}>
                     <ErrorBoundary>
                         <Routes>
@@ -118,7 +122,7 @@ function AdminRouter() {
                         </Routes>
                     </ErrorBoundary>
                 </div>
-            </div>
+            </main>
         </div>
     );
 }

--- a/resources/scripts/routers/DashboardRouter.tsx
+++ b/resources/scripts/routers/DashboardRouter.tsx
@@ -123,7 +123,7 @@ function DashboardRouter() {
                     </div>
                 </Sidebar.User>
             </Sidebar>
-            <div className={'flex-1 overflow-x-hidden'}>
+            <main className={'min-w-0 flex-1 overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0'}>
                 <NavigationBar />
                 <Suspense fallback={<Spinner centered />}>
                     <Routes>
@@ -140,7 +140,7 @@ function DashboardRouter() {
                         <Route path="*" element={<NotFound />} />
                     </Routes>
                 </Suspense>
-            </div>
+            </main>
         </div>
     );
 }

--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -183,7 +183,11 @@ function ServerRouter() {
                         <Spinner size="large" centered />
                     )
                 ) : (
-                    <div className={'flex-1 overflow-x-hidden'}>
+                    <main
+                        className={
+                            'min-w-0 flex-1 overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0'
+                        }
+                    >
                         <InstallListener />
                         <TransferListener />
                         <WebsocketHandler />
@@ -212,7 +216,7 @@ function ServerRouter() {
                                 </Routes>
                             </ErrorBoundary>
                         )}
-                    </div>
+                    </main>
                 )}
             </div>
         </Fragment>


### PR DESCRIPTION
## What

- fixes render-time state updates in the mobile navigation
- improves mobile touch targets, active states, scrolling, and iOS safe-area support
- prevents the bottom navigation from covering dashboard, server, and admin content
- makes breadcrumbs responsive on narrow screens
- restores visible keyboard focus indicators

## Validation

- [x] changed files formatted with the repository Prettier configuration
- [x] ESLint passes for all changed TypeScript files
- [x] `pnpm build` passes on Node 24
- [x] `git diff --check` passes
- [x] no dependency or lockfile changes

## Scope

This replacement for #581 intentionally contains only the focused UI/mobile fixes. Dependency security updates will be handled separately to avoid coupling framework upgrades with layout changes.