### PR TITLE
fix(api): restore application and client response handling

### DIFF
--- a/app/Http/Controllers/Api/Application/ApplicationApiController.php
+++ b/app/Http/Controllers/Api/Application/ApplicationApiController.php
@@ -60,7 +60,7 @@ abstract class ApplicationApiController extends Controller
      */
     protected function returnNoContent(): Response
     {
-        return $this->returnNoContent();
+        return new Response('', Response::HTTP_NO_CONTENT);
     }
 
     /**

--- a/app/Http/Controllers/Api/Application/ApplicationApiController.php
+++ b/app/Http/Controllers/Api/Application/ApplicationApiController.php
@@ -76,7 +76,7 @@ abstract class ApplicationApiController extends Controller
         ];
     }
 
-    protected function transform(mixed $data, string $transformer): array
+    protected function transform(mixed $data, string $transformer, ?bool $asCollection = null): array
     {
         $transformerInstance = is_string($transformer)
             ? app($transformer)
@@ -90,7 +90,9 @@ abstract class ApplicationApiController extends Controller
                 ->toArray();
         }
 
-        $resource = is_iterable($data)
+        $isCollection = $asCollection ?? ($data instanceof Collection || (is_array($data) ? array_is_list($data) : is_iterable($data)));
+
+        $resource = $isCollection
             ? $this->fractal->collection($data)
             : $this->fractal->item($data);
 

--- a/app/Http/Controllers/Api/Application/Users/UserController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserController.php
@@ -6,6 +6,7 @@ use Everest\Models\User;
 use Illuminate\Support\Arr;
 use Everest\Facades\Activity;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\AllowedFilter;
 use Everest\Exceptions\DisplayException;
@@ -129,7 +130,7 @@ class UserController extends ApplicationApiController
      * @throws \Exception
      * @throws \Everest\Exceptions\Model\DataValidationException
      */
-    public function store(StoreUserRequest $request): array
+    public function store(StoreUserRequest $request): JsonResponse
     {
         $user = $this->creationService->handle($request->validated());
 
@@ -138,7 +139,10 @@ class UserController extends ApplicationApiController
             ->description('A user was created')
             ->log();
 
-        return $this->transform($user, UserTransformer::class);
+        return response()->json(
+            $this->transform($user, UserTransformer::class),
+            Response::HTTP_CREATED,
+        );
     }
 
     /**

--- a/app/Http/Controllers/Api/Client/ClientApiController.php
+++ b/app/Http/Controllers/Api/Client/ClientApiController.php
@@ -10,8 +10,10 @@ abstract class ClientApiController extends ApplicationApiController
     /**
      * Returns only the includes which are valid for the given transformer.
      */
-    protected function getIncludesForTransformer(Transformer $transformer, array $merge = []): array
+    protected function getIncludesForTransformer(Transformer|string $transformer, array $merge = []): array
     {
+        $transformer = is_string($transformer) ? app($transformer) : $transformer;
+
         $filtered = array_filter($this->parseIncludes(), function ($datum) use ($transformer) {
             return in_array($datum, $transformer->getAvailableIncludes());
         });

--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -179,7 +179,7 @@ class FileController extends ClientApiController
             ->property('files', $request->input('files'))
             ->log();
 
-        return $this->transform($file, FileObjectTransformer::class);
+        return $this->transform($file, FileObjectTransformer::class, false);
     }
 
     /**

--- a/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
@@ -34,6 +34,6 @@ class ResourceUtilizationController extends ClientApiController
             return $this->repository->setServer($server)->getDetails();
         });
 
-        return $this->transform($stats, StatsTransformer::class);
+        return $this->transform($stats, StatsTransformer::class, false);
     }
 }

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
@@ -137,7 +137,7 @@ class ScheduleController extends ClientApiController
 
         Activity::event('server:schedule.execute')->subject($schedule)->property('name', $schedule->name)->log();
 
-        return $this->returnNoContent();
+        return $this->returnAccepted();
     }
 
     /**

--- a/app/Http/Controllers/Api/Client/Servers/SettingsController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SettingsController.php
@@ -66,7 +66,7 @@ class SettingsController extends ClientApiController
 
         Activity::event('server:reinstall')->log();
 
-        return $this->returnNoContent();
+        return $this->returnAccepted();
     }
 
     /**


### PR DESCRIPTION
## Summary

- restore HTTP 201 responses when creating application users
- stop infinite recursion when returning HTTP 204 responses
- accept transformer class names when resolving requested includes
- preserve item responses for associative/empty API payloads
- restore HTTP 202 responses for schedule execution and server reinstall actions

## Root cause

A transformer-helper refactor on the current develop baseline changed several established API response contracts. It also made eturnNoContent() recursively call itself, causing the integration suite to hang until GitHub terminated the runner.

## Validation

- PHP CS Fixer passes on every changed controller
- unit suite passes: 86 tests, 138 assertions
- after the recursion fix, the integration suite completes all 293 tests instead of hanging; the follow-up fixes address all 16 surfaced failures
- GitHub Actions is validating PHP 8.2-8.4 against MySQL and MariaDB